### PR TITLE
Skip disabled devices in MQTT subscribe loop and coordinator refresh

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -108,7 +108,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not sn:
             return False
         dev_entry = device_registry.async_get_device(identifiers={(DOMAIN, sn)})
-        return dev_entry is None or dev_entry.disabled_by is None
+        if dev_entry is not None and dev_entry.disabled_by is not None:
+            _LOGGER.info(
+                "Skipping disabled device %s (disabled_by=%s)",
+                sn, dev_entry.disabled_by,
+            )
+            return False
+        return True
 
     devices = [d for d in devices if _is_enabled(d.get("sn", ""))]
 

--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -99,6 +99,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not devices:
         _LOGGER.warning("No Irrisense (WRX/WGX) devices found on this account")
 
+    # Filter out devices the user has disabled in HA's device registry.
+    # Devices not yet in the registry are let through so first-time setup
+    # registers them; subsequent reloads honour the user's disable.
+    device_registry = dr.async_get(hass)
+
+    def _is_enabled(sn: str) -> bool:
+        if not sn:
+            return False
+        dev_entry = device_registry.async_get_device(identifiers={(DOMAIN, sn)})
+        return dev_entry is None or dev_entry.disabled_by is None
+
+    devices = [d for d in devices if _is_enabled(d.get("sn", ""))]
+
     coordinator = IrrisenseCoordinator(hass, api, entry)
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -245,6 +245,7 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                     identifiers={(DOMAIN, sn)}
                 )
                 if dev_entry is not None and dev_entry.disabled_by is not None:
+                    _LOGGER.debug("Skipping disabled device %s in refresh", sn)
                     continue
                 await self._refresh_device(sn, dev)
 

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -234,9 +235,16 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             # enough, but it also catches new devices being added).
             await self.hass.async_add_executor_job(self.api.get_devices)
 
+            device_registry = dr.async_get(self.hass)
             for dev in self.devices:
                 sn = dev.get("sn")
                 if not sn:
+                    continue
+                # Skip devices the user has disabled in HA's device registry.
+                dev_entry = device_registry.async_get_device(
+                    identifiers={(DOMAIN, sn)}
+                )
+                if dev_entry is not None and dev_entry.disabled_by is not None:
                     continue
                 await self._refresh_device(sn, dev)
 


### PR DESCRIPTION
Closes #10.

  Devices that the user has disabled in HA's device registry (`disabled_by` non-None) were still polled by the coordinator and subscribed via MQTT on every setup and every refresh. On a 2-device account with one device disabled this doubled per-attempt work.
  Neither `__init__.py` nor `coordinator.py` previously consulted the registry.
 
  ## Changes

  - `__init__.py` — after `devices = await api.get_devices()`, filter the list against `dr.async_get_device(...).disabled_by`. New devices not yet in the registry are let through so first-time setup still registers them. The downstream MQTT
  subscribe/query/shadow loop and the device-registry register loop then naturally skip disabled SNs.
  - `coordinator.py` — add the same check inside `_async_update_data` before `_refresh_device(sn, dev)`. Re-checking on every pass means re-enabling a device picks up at the next refresh without a config-entry reload.

  Both filters consult the same `DeviceRegistry` that HA's UI mutates when the user disables a device.

  ## Test plan (manual)

  On an account with two devices, disable one in **Settings → Devices → … → Disable**, restart HA, watch the log at DEBUG level for `aiper_irrisense.api`. Before this PR: REST calls and MQTT subscribes appear for both serials. After: only the enabled serial is
  touched. Re-enabling the device at runtime → next coordinator refresh resumes polling.
 
  ## Known limitations
  
  - **MQTT re-subscribe needs a reload.** MQTT subscriptions are set up only in `async_setup_entry`, so re-enabling a device at runtime restores REST polling on the next coordinator refresh but does not re-subscribe MQTT until the integration is reloaded.
  - **Entity creation at setup time.** Platforms iterate `coordinator.devices` in their `async_setup_entry` and create entity classes for every SN the cloud returned. HA Core's standard cascade-disable hides entities of a disabled device, so this PR's scope is
  the per-device REST/MQTT runtime load only — entity creation is unaffected by design.
 
  ## Not in scope

  The setup-time bootstrap blockage (#11) is independent and additive — the disabled-filter alone helps but does not fix that. Will follow up separately.