### PR TITLE
Read watering binary_sensor from active_zone_state

### DIFF
--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -66,19 +66,12 @@ class WateringBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        # Prefer the most recent MQTT setWorkMode ACK or workInfoReport.
-        mqtt = self._mqtt
-        for key in ("up_setWorkMode", "up_workInfoReport", "up_workInfo", "up_realtimeStatus"):
-            msg = mqtt.get(key)
-            if isinstance(msg, dict):
-                body = msg.get("data")
-                if isinstance(body, dict):
-                    status = body.get("status")
-                    if status in (1, "1"):
-                        return True
-                    if status in (0, "0", 2, "2"):
-                        return False
-        return False
+        # Delegate to active_zone_state so this entity tracks the same
+        # source-of-truth as ActiveZoneSensor — _ACTIVE_SOURCES covers
+        # up_realTimeProgress + freshest-frame picks, avoiding stale-slot
+        # divergence (issue #4).
+        state = self.coordinator.active_zone_state(self._sn)
+        return bool(state and state.get("is_running"))
 
 
 class RainSensingBinarySensor(IrrisenseEntity, BinarySensorEntity):

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -66,10 +66,8 @@ class WateringBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        # Delegate to active_zone_state so this entity tracks the same
-        # source-of-truth as ActiveZoneSensor — _ACTIVE_SOURCES covers
-        # up_realTimeProgress + freshest-frame picks, avoiding stale-slot
-        # divergence (issue #4).
+        # Delegate to active_zone_state — its freshest-frame pick across
+        # _ACTIVE_SOURCES avoids stale-slot divergence (issue #4).
         state = self.coordinator.active_zone_state(self._sn)
         return bool(state and state.get("is_running"))
 


### PR DESCRIPTION
WateringBinarySensor.is_on previously walked a hardcoded 4-key MQTT slot list (up_setWorkMode, up_workInfoReport, up_workInfo, up_realtimeStatus) in priority order, returning True/False on the first slot that carried a status field. This diverged from ActiveZoneSensor, which reads via coordinator.active_zone_state and picks the freshest frame across _ACTIVE_SOURCES (5 slots including up_realTimeProgress).

Two failure modes from that divergence:

- Stuck off during a run started outside HA (mobile app / device touch): no up_setWorkMode echo lands in the slot, the other three keys are usually missing or stale at status=0, the loop falls through to return False. Meanwhile up_realTimeProgress arrives continuously and active_zone_state correctly reports running. Original report in #4.

- Stuck on after a run ends: device does not echo setWorkMode on stop, so the last status=1 echo persists in the up_setWorkMode slot indefinitely. is_on hits it first in priority order and returns True even though active_zone_state's freshest-frame logic has already transitioned to Idle. Reproduced on V3.9.4 / Area zone, recorder window 16:45:00 → 16:47:38 UTC 2026-05-26: binary sensor was on for 2.5 min while active_zone was Idle, before a separate Rasen_V2 run actually started.

Both symptoms are eliminated by reading from the same source as ActiveZoneSensor.

- custom_components/aiper_irrisense/binary_sensor.py: replace the 4-key loop in WateringBinarySensor.is_on with a single call to coordinator.active_zone_state(self._sn).get("is_running").

Closes #4.