### PR TITLE
Drop water_pressure sensor and active_zone attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use them in automations and dashboards.
 - **Control:** start / stop watering per zone, pick dose (Area / Line) or
   duration (Point) from a zone-aware select entity.
 - **Live telemetry:** active zone, elapsed / remaining seconds, progress %,
-  coverage passes, water pressure, rain-sensing state.
+  coverage passes, rain-sensing state.
 - **Device info:** firmware versions (main / MCU / valve), Wi-Fi RSSI,
   lifetime water delivered / saved, watering-event count.
 - **Settings:** toggle rain-sensing, wind-sensing, drainage / pesticide /
@@ -76,12 +76,11 @@ so a device called *IrriSense Garden* will have
 | `select`        | Watering zone                 | Options are the zones on the device's zone map                          |
 | `select`        | Dose / Duration               | Shape-shifts: `3mm / 6mm / 13mm` for Area/Line, `1min / 5min / 10min` for Point |
 | `select`        | Nozzle type                   | Stream / Rotor / etc.                                                   |
-| `sensor`        | Active zone                   | Name of the zone currently running. Key attributes: `dose_label`, `duration_seconds`, `duration_pending`, `start_time`, `elapsed_seconds`, `repair_layer`, `progress`, `water_pressure_kpa` |
+| `sensor`        | Active zone                   | Name of the zone currently running. Key attributes: `dose_label`, `duration_seconds`, `duration_pending`, `start_time`, `elapsed_seconds`, `repair_layer`, `progress` |
 | `sensor`        | Progress                      | 0–100 %. Spike-filtered                                                 |
 | `sensor`        | Elapsed seconds               | Time since the current run started                                      |
 | `sensor`        | Run total seconds             | Expected duration of the current run                                    |
 | `sensor`        | Coverage passes               | `repair_layer` from the device (0-indexed; humans usually want `+1`)    |
-| `sensor`        | Water pressure                | kPa                                                                     |
 | `sensor`        | WiFi signal                   | dBm                                                                     |
 | `sensor`        | Firmware version / MCU / Valve| Three separate sensors                                                  |
 | `sensor`        | Total water delivered / saved | Litres (lifetime)                                                       |

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -984,14 +984,13 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         _m, _s = divmod(_rem, 60)
         duration_hms = f"{_h}:{_m:02d}:{_s:02d}"
 
-        # Surface the sprinkler-motion + pressure fields the APK's
+        # Surface the sprinkler-motion fields the APK's
         # `realTimeProgress` handler publishes:
         #   * `x`, `y`           — head position in the zone's local coord
         #                          system (updates every realTimeProgress
         #                          frame).
         #   * `repairLayer`      — coverage-pass counter (increments as the
         #                          head re-sweeps the zone).
-        #   * `waterpress`       — live line pressure.
         rl_val = _fallback("repairLayer")
 
         return {
@@ -1007,7 +1006,6 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             "x": _fallback("x"),
             "y": _fallback("y"),
             "repair_layer": rl_val,
-            "water_pressure": _fallback("waterpress"),
             "source": freshest_key,
             "source_ts": freshest_ts,
             "start_ts": start_ts,

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -37,7 +37,6 @@ async def async_setup_entry(
                 ActiveElapsedSensor(coordinator, sn),
                 ActiveTotalSensor(coordinator, sn),
                 ActiveProgressSensor(coordinator, sn),
-                ActivePressureSensor(coordinator, sn),
                 ActiveRepairLayerSensor(coordinator, sn),
                 FirmwareSensor(coordinator, sn),
                 McuFirmwareSensor(coordinator, sn),
@@ -104,11 +103,10 @@ class ActiveZoneSensor(IrrisenseEntity, SensorEntity):
         if isinstance(start_ts, (int, float)):
             start_iso = datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat()
 
-        # Surface sprinkler-motion + pressure fields the APK's
-        # realTimeProgress handler publishes. `x` / `y` are the sprinkler
-        # head position in the zone's coordinate system; `repair_layer` is
-        # the coverage-pass counter; `water_pressure_kpa` is the live line
-        # pressure.
+        # Surface sprinkler-motion fields the APK's realTimeProgress
+        # handler publishes. `x` / `y` are the sprinkler head position
+        # in the zone's coordinate system; `repair_layer` is the
+        # coverage-pass counter.
         return {
             "is_running": True,
             "zone_id": state.get("zone_id"),
@@ -123,7 +121,6 @@ class ActiveZoneSensor(IrrisenseEntity, SensorEntity):
             "x": state.get("x"),
             "y": state.get("y"),
             "repair_layer": state.get("repair_layer"),
-            "water_pressure_kpa": state.get("water_pressure"),
             "source": state.get("source"),
             "start_time": start_iso,
             "duration_seconds": state.get("duration_seconds"),
@@ -253,34 +250,6 @@ class ActiveProgressSensor(_ActiveMetricBase):
             and total > 0
         ):
             return round(max(0.0, min(100.0, (t / total) * 100.0)), 1)
-        return None
-
-
-class ActivePressureSensor(_ActiveMetricBase):
-    """Water-line pressure in kPa during the current run.
-
-    Confirmed from the APK's realTimeProgress handler — the wire key is
-    ``waterpress`` (no underscore). The device publishes this live on
-    every progress frame and it's handy for a health sub-panel.
-    """
-
-    _attr_icon = "mdi:gauge"
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "kPa"
-    _attr_translation_key = "active_pressure"
-
-    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
-        super().__init__(coordinator, sn, "active_pressure")
-        self._attr_name = "Water pressure"
-
-    @property
-    def native_value(self) -> float | None:
-        live = self._live()
-        if not live:
-            return None
-        p = live.get("water_pressure")
-        if isinstance(p, (int, float)):
-            return round(float(p), 1)
         return None
 
 

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -49,7 +49,6 @@
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
-      "active_pressure": {"name": "Water pressure"},
       "active_repair_layer": {"name": "Coverage passes"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -49,7 +49,6 @@
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
-      "active_pressure": {"name": "Water pressure"},
       "active_repair_layer": {"name": "Coverage passes"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},


### PR DESCRIPTION
Closes #5.

The V3.8.7+ firmware does not publish `waterpress` on `realTimeProgress` frames, so `coordinator._fallback("waterpress")` latches transient values from unrelated MQTT shadow frames. The 14-day Recorder trace in the issue body shows the textbook signature: 3 sub-second flashes of `167.5` and `unknown` everywhere else, including during active runs. The hero-dashboard chip reading `state_attr('sensor.<device>_active_zone', 'water_pressure_kpa') | float(0)` displays 0 kPa as a consequence.

Per the triage comment on #6: this is a regression of a 0.1.5.11 pathology — the surface (entity + attribute) was previously removed and reintroduced before 0.2.0. Removing it again, with the Boy Scout cleanup of the now-orphan fallback resolution.

## Changes

- `custom_components/aiper_irrisense/sensor.py` — remove `ActivePressureSensor` class, its instantiation in `async_setup_entry`, the `water_pressure_kpa` attribute on `ActiveZoneSensor.extra_state_attributes`, and the comment-block reference.
- `custom_components/aiper_irrisense/strings.json` + `custom_components/aiper_irrisense/translations/en.json` — drop the `active_pressure` translation key.
- `README.md` — drop `water_pressure_kpa` from the `Active zone` row's attribute list, drop the `Water pressure` row from the entities table, drop the "water pressure" mention in the live-telemetry feature list.
- `custom_components/aiper_irrisense/coordinator.py` — Boy Scout — drop `"water_pressure": _fallback("waterpress")` in `active_zone_state` and the `waterpress` bullet in its comment block. No remaining consumers in `custom_components/`.

Total diff: 5 files, +7 −43.

## Migration impact

Existing installs that already had this surface need to handle two HA-side artefacts after updating:

**1. Orphan entity `sensor.<device>_water_pressure`**

Transitions to `unavailable` and lingers in the entity registry until manually removed via Settings → Devices & services → Aiper Irrisense → Entities → `sensor.<device>_water_pressure` → ⋮ → Remove. This is HA's standard entity-removal behaviour; Recorder history is preserved per HA's normal retention.

**2. Removed attribute `sensor.<device>_active_zone.attributes.water_pressure_kpa`**

Any automation or dashboard that referenced the attribute needs attention:

- **Automations** with `numeric_state` triggers on `attribute: water_pressure_kpa` will produce a load-time WARNING and never fire. Note: the trigger also never fired pre-PR in practice, because the firmware-reported `waterpress` field was unreliable (mostly `None`). The PR converts a silently-broken trigger into a visibly-broken one. Migration options:
  - **Disable the trigger leg** with a comment referencing this PR — preserves the automation structure if a future firmware revision restores reliable pressure publishing.
  - **Substitute an independent pressure source** (e.g., an inline water-meter pressure sensor) if available.
  - **Derive a proxy** via a `derivative` helper on pump-power — a sudden drop on the pump load can indirectly flag a free-flow / pressure-loss scenario.
  - **Retire the trigger leg** entirely if other safety paths (e.g., pump-power-based watchdogs) already provide sufficient coverage.

- **Dashboards** referencing the attribute in templates should already None-guard the value (otherwise they would have been broken pre-PR). Cards with `tap_action.entity: sensor.<device>_water_pressure` should be repointed (e.g., to `sensor.<device>_active_zone` for `more-info`) or removed entirely.

No config-flow migration is required on the integration side.

## Test plan (manual)

- After update, confirm `sensor.<device>_water_pressure` transitions to `unavailable` and the entity is gone after manual removal from the entity registry.
- Start any zone run and confirm the remaining `ActiveZoneSensor`, `ActiveElapsedSensor`, `ActiveTotalSensor`, `ActiveProgressSensor`, `ActiveRepairLayerSensor` continue to populate from `coordinator.active_zone_state()` unchanged.
- Confirm `sensor.<device>_active_zone` `extra_state_attributes` no longer contains `water_pressure_kpa`.

## Known limitations

- Removal only. If a future firmware re-introduces reliable `waterpress` publishing on `realTimeProgress`, the entity + attribute can be reintroduced with a feature-detect guard. Not part of this PR.

## Not in scope

- Other water_pressure mentions in unrelated codepaths — `api.py:603`'s `_parse_regions` docstring references `waterpress` as a per-region-point field in the raw zone-map JSON; that field has always been discarded by the parser as bloat (independent of the realTimeProgress `waterpress` this PR addresses).
- Test harness setup — repo has no `tests/` directory or CI; this PR follows the project's manual-test-plan convention (same as PR #14).