### PR TITLE
Bound setup latency with timeouts + background MQTT

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -1,6 +1,7 @@
 """Aiper Irrisense 2 — Home Assistant integration entry point."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -9,6 +10,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .api import IrrisenseApi
@@ -90,34 +92,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     api.mqtt_debug = bool(entry.options.get(CONF_MQTT_DEBUG, False))
 
-    # Auth + device discovery on the executor
-    ok = await hass.async_add_executor_job(api.login)
-    if not ok:
-        return False
+    # Auth + device discovery on the executor. Wrapped in asyncio.wait_for
+    # so a slow cloud round-trip cannot push the setup coroutine past HA's
+    # 60s bootstrap window. ConfigEntryNotReady triggers HA's exponential
+    # backoff retry rather than the no-retry SETUP_ERROR path. See #11.
+    try:
+        await asyncio.wait_for(
+            hass.async_add_executor_job(api.login), timeout=15
+        )
+        devices = await asyncio.wait_for(
+            hass.async_add_executor_job(api.get_devices), timeout=15
+        )
+    except Exception as ex:  # noqa: BLE001 - covers TimeoutError + api.login's raised Exception variants
+        raise ConfigEntryNotReady(
+            f"Aiper cloud unavailable during setup: {ex}"
+        ) from ex
 
-    devices = await hass.async_add_executor_job(api.get_devices)
     if not devices:
         _LOGGER.warning("No Irrisense (WRX/WGX) devices found on this account")
 
     coordinator = IrrisenseCoordinator(hass, api, entry)
     await coordinator.async_config_entry_first_refresh()
 
-    # MQTT (optional; on by default)
+    # MQTT (optional; on by default) — runs as an entry-bound background
+    # task so a slow AWS IoT connect (~30s blocking) plus per-device
+    # subscribe loop do not delay the setup coroutine. The integration
+    # comes up REST-poll-only; MQTT real-time updates join in the
+    # background as soon as connect + subscribes complete. See #11.
     if entry.options.get(CONF_ENABLE_MQTT, True):
-        mqtt_ok = await hass.async_add_executor_job(api.connect_mqtt)
-        if mqtt_ok:
-            for dev in devices:
-                sn = dev.get("sn")
-                if not sn:
-                    continue
-                await hass.async_add_executor_job(
-                    api.subscribe_device, sn, coordinator.handle_mqtt_message
-                )
-                # Nudge the device to report current state.
-                await hass.async_add_executor_job(api.query_work_info, sn)
-                await hass.async_add_executor_job(api.request_shadow, sn)
-        else:
-            _LOGGER.warning("Irrisense MQTT connect failed — realtime disabled")
+        entry.async_create_background_task(
+            hass,
+            _async_setup_mqtt_background(hass, api, devices, coordinator),
+            f"aiper_irrisense_mqtt_setup_{entry.entry_id}",
+        )
 
     # Register devices in the device registry.
     device_registry = dr.async_get(hass)
@@ -147,6 +154,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _register_services(hass)
     return True
+
+
+async def _async_setup_mqtt_background(
+    hass: HomeAssistant,
+    api: IrrisenseApi,
+    devices: list[dict[str, Any]],
+    coordinator: IrrisenseCoordinator,
+) -> None:
+    """MQTT connect + per-device subscribe, off the setup path.
+
+    Issue #11: AWS IoT `connect_mqtt` is up to 30s blocking
+    (`configureConnectDisconnectTimeout(30)`) and the per-device
+    subscribe / query_work_info / request_shadow loop adds several
+    seconds on top. Together they push the setup coroutine over HA's
+    60s bootstrap window. Running this off the setup path keeps the
+    integration responsive: entities come online via REST-only
+    polling first, MQTT layers on as soon as the connect resolves.
+    """
+    try:
+        mqtt_ok = await hass.async_add_executor_job(api.connect_mqtt)
+        if not mqtt_ok:
+            _LOGGER.warning("Irrisense MQTT connect failed — realtime disabled")
+            return
+        for dev in devices:
+            sn = dev.get("sn")
+            if not sn:
+                continue
+            await hass.async_add_executor_job(
+                api.subscribe_device, sn, coordinator.handle_mqtt_message
+            )
+            # Nudge the device to report current state.
+            await hass.async_add_executor_job(api.query_work_info, sn)
+            await hass.async_add_executor_job(api.request_shadow, sn)
+    except Exception:  # noqa: BLE001 - diagnostic only
+        _LOGGER.exception("Irrisense MQTT background setup failed")
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .api import IrrisenseApi
@@ -103,9 +103,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         devices = await asyncio.wait_for(
             hass.async_add_executor_job(api.get_devices), timeout=15
         )
-    except Exception as ex:  # noqa: BLE001 - covers TimeoutError + api.login's raised Exception variants
+    except TimeoutError as ex:
         raise ConfigEntryNotReady(
-            f"Aiper cloud unavailable during setup: {ex}"
+            f"Aiper cloud timeout during setup (check network): {ex}"
+        ) from ex
+    except Exception as ex:  # noqa: BLE001 - api.login distinguishes auth vs other via message text
+        # api.login raises Exception("Login failed: ...") on cloud-rejected
+        # credentials and Exception("No token in login response: ...") on
+        # protocol errors. Both are permanent config problems that should
+        # trigger HA's reauth flow rather than infinite ConfigEntryNotReady
+        # backoff. Discriminate by message prefix; anything else falls
+        # back to transient cloud-error retry.
+        if "Login failed" in str(ex) or "No token" in str(ex):
+            raise ConfigEntryAuthFailed(
+                f"Aiper authentication failed: {ex}"
+            ) from ex
+        raise ConfigEntryNotReady(
+            f"Aiper cloud error during setup: {ex}"
         ) from ex
 
     if not devices:
@@ -119,7 +133,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # subscribe loop do not delay the setup coroutine. The integration
     # comes up REST-poll-only; MQTT real-time updates join in the
     # background as soon as connect + subscribes complete. See #11.
-    if entry.options.get(CONF_ENABLE_MQTT, True):
+    # Skipped entirely if the account has no Irrisense devices —
+    # connecting MQTT to subscribe to nothing is a 30s waste.
+    if entry.options.get(CONF_ENABLE_MQTT, True) and devices:
         entry.async_create_background_task(
             hass,
             _async_setup_mqtt_background(hass, api, devices, coordinator),
@@ -187,7 +203,7 @@ async def _async_setup_mqtt_background(
             # Nudge the device to report current state.
             await hass.async_add_executor_job(api.query_work_info, sn)
             await hass.async_add_executor_job(api.request_shadow, sn)
-    except Exception:  # noqa: BLE001 - diagnostic only
+    except Exception:  # noqa: BLE001 - MQTT is optional; don't crash integration load
         _LOGGER.exception("Irrisense MQTT background setup failed")
 
 


### PR DESCRIPTION
Closes #11.

`async_setup_entry` chains four blocking executor calls — `api.login`, `api.get_devices`, `coordinator.async_config_entry_first_refresh`, `api.connect_mqtt` — plus a per-device MQTT subscribe loop, with no per-phase timeout and no `ConfigEntryNotReady` path on early failures. `coordinator.async_config_entry_first_refresh` already auto-raises `ConfigEntryNotReady` on `UpdateFailed`, but the other phases either propagate raw exceptions or silently return `False`, which puts the entry into `SETUP_ERROR` with no retry. The MQTT connect alone is up to 30 s blocking (AWS IoT SDK's `configureConnectDisconnectTimeout(30)`). The chain routinely overran HA's 60 s bootstrap window — the OP log on the issue body captured a 2-device account taking 4 min 17 s to come up, with three intermediate SETUP cancellations at 60 s intervals.

Four changes on the setup path:

- **Wrap `api.login` and `api.get_devices` in `asyncio.wait_for(timeout=15)`** with a three-branch except chain: `TimeoutError` → `ConfigEntryNotReady` (network), `Exception` whose message starts with the known `api.login` auth prefixes (`"Login failed: ..."` for cloud-rejected credentials, `"No token in login response: ..."` for protocol error) → `ConfigEntryAuthFailed` (triggers HA's reauth flow), anything else → `ConfigEntryNotReady` (other transient cloud issues). HA's exponential backoff retries CENR automatically (capped at 1 h); CEAF prompts the user to re-enter credentials via the standard reauth UI.

- **Drop the dead `if not ok: return False` guard.** `api.login` raises on every failure path; the False-return branch was unreachable.

- **Extract the MQTT connect + per-device subscribe loop into `_async_setup_mqtt_background`** scheduled via `entry.async_create_background_task`. The integration comes online REST-poll-only within ~25 s and the MQTT real-time channel layers on asynchronously when the connect resolves.

- **Gate the MQTT background task on `devices` being non-empty.** If `api.get_devices()` returns `[]`, MQTT-connect is a 30 s waste with nothing to subscribe to. The warning + REST-coordinator-creation path still runs; only the MQTT task is skipped.

`coordinator.async_config_entry_first_refresh` stays in the setup coroutine — it auto-raises `ConfigEntryNotReady` on `UpdateFailed` and its result is required for the entity-creation flow downstream.

## Changes

- `custom_components/aiper_irrisense/__init__.py`:
  - add `asyncio` + `homeassistant.exceptions.{ConfigEntryAuthFailed, ConfigEntryNotReady}` imports.
  - wrap login + get_devices in `try` / `asyncio.wait_for(timeout=15)` with TimeoutError / auth-message-prefix / fallback dispatch.
  - replace the inline MQTT connect/subscribe block with a call to `entry.async_create_background_task` that schedules a new module function `_async_setup_mqtt_background`.
  - gate the MQTT background task on `devices` being non-empty.

Total diff: 1 file, +79 −21.

## Test plan (manual)

Verified on a 2-device account (V3.9.4 firmware) by HACS-installing a combined test build (this PR cherry-picked on top of #15 + #18 to avoid regression confounds) and triggering a HA restart:

- Pre-PR baseline (same install, prior restart cycles): ~6-7 min restart wait with 3-4 SETUP-RETRY entries in the log at 60 s intervals.
- Post-PR (same install, this commit active): ~4 min 21 s total restart wait — single clean setup, zero retries, zero `aiper_irrisense`-prefixed WARNING or ERROR lines in `home-assistant.log`.
- The difference (~2-3 min) is the eliminated retry loop. Total restart wait is now bounded by HA-core boot time (which #11 does not address); the aiper-portion fits inside the HA-core envelope rather than extending it.

To re-run on your own install:

1. Note timestamp of `ha.restart`.
2. Wait for `binary_sensor.<device>_online` to transition to `on`.
3. Compare delta with the pre-PR baseline. Look in `home-assistant.log` for `Setup of config entry … cancelled` lines — none expected.

## Migration impact

Pure improvement for the setup path; no entity-surface change. Existing installs that have been sitting in `SETUP_ERROR` because their previous startup overran the 60 s window will, on the next HA restart, see the integration come up cleanly via `ConfigEntryNotReady` + HA's standard retry-on-failure path. No user action required.

Automations that trigger on `homeassistant.start` or `event: start` and reference Aiper entities could in principle observe entities sooner than before (the integration appears within ~25-30 s post-restart instead of 5+ min). In a sweep of one production install, no automations matched that trigger pattern against Aiper entities; reviewers may want to verify on their own install before relying on the new timing.

During the ~30 s window between setup-coro completion and MQTT background task finishing, entities are populated from REST-poll data only. The active-zone state shows `Idle` / `off` correctly during that window if no run is active. If a run is active at the moment of restart, MQTT-driven progress fields take ~30 s to start updating; the entities are not lost, just temporarily REST-only.

## Known limitations

- Auth-vs-transient discrimination is done by message-prefix matching on `api.login`'s `Exception` text. The relevant prefixes (`"Login failed: ..."` and `"No token in login response: ..."`) are owned by `api.py` in this repo, so the format is under our control, but the coupling is implicit. A cleaner separation would have `api.py` raise a dedicated `AiperAuthError` subclass for the auth-rejected branches and let the integration catch that explicitly. Out of scope for this PR; the message-prefix split is the minimal change that delivers the user-facing reauth-flow benefit without an `api.py` refactor.

- HA-core boot time itself (the ~3-4 min before integrations begin loading on a custom_components-heavy install) is unchanged. This PR addresses the aiper-specific contribution to restart wait, not the platform-wide baseline.

## Not in scope

- HA-core-boot optimisations — not the integration's concern.
- `api.py` refactor to distinguish transient vs auth failures — separate, focused change.
- Failure-mode test (simulated cloud-down) — code-path is trivial (`try` / `wait_for` / `raise CENR`) and the happy-path success on a real install plus the absence of SETUP-RETRY logs are stronger evidence than a simulated outage would have produced. If a reviewer wants to exercise the failure path: block `apieurope.aiper.com` in DNS for one restart cycle and confirm `ConfigEntryNotReady` appears in the log + the entry enters `SETUP_RETRY` with backoff.