### PR TITLE
Declare water totals in gallons — backend reports gal, not liters

### DIFF
--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -406,7 +406,9 @@ class WifiRssiSensor(IrrisenseEntity, SensorEntity):
 class TotalWaterYieldSensor(IrrisenseEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.WATER
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
+    # Backend reports gallons (see the inch-based depth presets in const.py);
+    # declare gallons and let HA convert for metric users.
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_icon = "mdi:water"
     _attr_translation_key = "total_water_yield"
 
@@ -427,7 +429,7 @@ class TotalWaterYieldSensor(IrrisenseEntity, SensorEntity):
 class TotalWaterSavingSensor(IrrisenseEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.WATER
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_icon = "mdi:water-check"
     _attr_translation_key = "total_water_saving"
 


### PR DESCRIPTION
While hooking the water totals up to the HA energy dashboard I noticed my numbers were way off compared to the Aiper app, and I think I found the root cause of #9: `totalWaterYield` and `totalWaterSavingAmount` from `/wr/wateringRecordStatisticsV2` are in US gallons, but the sensors declare liters.

Evidence:

- My device: the API returns `totalWaterYield: 16.1` while the app shows 62 L. 16.1 gal = 60.9 L, which matches (app data was slightly fresher than my last 6h stats poll).
- Same for water saved: API says 10.73, the app shows ~41 L. 10.73 gal = 40.6 L.
- The screenshots in #9 show the same constant factor on *both* sensors: 876.79/229.35 = 3.823 and 584.55/152.91 = 3.823, which is the L-per-gal factor (3.785) plus a bit of drift from the stale stats cache.
- The wire protocol is imperial elsewhere too: the dosage presets in const.py map 0.1 → "3 mm", 0.25 → "6 mm", 0.5 → "13 mm", i.e. the depth field is inches.

So this just switches the two sensors to `UnitOfVolume.GALLONS` and lets HA's unit system convert for metric users. Energy dashboard handles the conversion fine as well.

One heads-up for existing installs: long-term statistics recorded so far are stored as liters, so HA will flag a unit mismatch once — fixable via Developer Tools → Statistics (or by clearing the stat).

The ~30% under-reporting against a real water meter mentioned in #9 is the device's own flow estimation and obviously out of scope here.