### PR TITLE
Remove unused imports (deque, TOPIC_SHADOW_UPDATE, parse_dose_label)

### DIFF
--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -20,7 +20,7 @@ import random
 import threading
 import time
 import weakref
-from collections import defaultdict, deque
+from collections import defaultdict
 from typing import Any, Callable
 
 import aiohttp
@@ -45,7 +45,6 @@ from .const import (
     TOPIC_READ,
     TOPIC_SHADOW_GET,
     TOPIC_SHADOW_GET_REQUEST,
-    TOPIC_SHADOW_UPDATE,
     TOPIC_SHADOW_UPDATE_ACCEPTED,
     TOPIC_SHADOW_UPDATE_DELTA,
     TOPIC_SHADOW_UPDATE_DOCUMENTS,

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -51,7 +51,6 @@ from .const import (
     default_dose_label_for_region_type,
     label_for_point_time,
     label_for_water_yield,
-    parse_dose_label,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 


### PR DESCRIPTION
Three imports are bound but never used:

- `api.py`: `deque` (from `collections`) and `TOPIC_SHADOW_UPDATE` (from `.const`)
- `coordinator.py`: `parse_dose_label` (from `.const`)

Each name appears only on its import line, so removing it changes no behavior. `ruff check --select F401` reports exactly these three on v0.3.0 and is clean afterwards.
