### PR TITLE
Broaden Irrisense prefix match to the 2-letter family

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -123,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     if not devices:
-        _LOGGER.warning("No Irrisense (WRX/WGX) devices found on this account")
+        _LOGGER.warning("No Irrisense (WRX/WGX/WCX) devices found on this account")
 
     # Filter out devices the user has disabled in HA's device registry.
     # Devices not yet in the registry are let through so first-time setup

--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -123,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     if not devices:
-        _LOGGER.warning("No Irrisense (WRX/WGX/WCX) devices found on this account")
+        _LOGGER.warning("No Irrisense (WR/WG/WC/WL) devices found on this account")
 
     # Filter out devices the user has disabled in HA's device registry.
     # Devices not yet in the registry are let through so first-time setup

--- a/custom_components/aiper_irrisense/config_flow.py
+++ b/custom_components/aiper_irrisense/config_flow.py
@@ -63,7 +63,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         await hass.async_add_executor_job(api.disconnect)
 
     if not devices:
-        # Account authenticated but no Irrisense (WRX / WGX) devices were returned
+        # Account authenticated but no Irrisense (WRX / WGX / WCX) devices were returned
         # — probably wrong account for Irrisense, or the user only owns pool cleaners.
         raise NoIrrisenseDevices
 
@@ -187,4 +187,4 @@ class InvalidAuth(HomeAssistantError):
 
 
 class NoIrrisenseDevices(HomeAssistantError):
-    """Account has no Irrisense (WRX / WGX) devices."""
+    """Account has no Irrisense (WRX / WGX / WCX) devices."""

--- a/custom_components/aiper_irrisense/config_flow.py
+++ b/custom_components/aiper_irrisense/config_flow.py
@@ -63,7 +63,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         await hass.async_add_executor_job(api.disconnect)
 
     if not devices:
-        # Account authenticated but no Irrisense (WRX / WGX / WCX) devices were returned
+        # Account authenticated but no Irrisense (WR / WG / WC / WL) devices were returned
         # — probably wrong account for Irrisense, or the user only owns pool cleaners.
         raise NoIrrisenseDevices
 
@@ -187,4 +187,4 @@ class InvalidAuth(HomeAssistantError):
 
 
 class NoIrrisenseDevices(HomeAssistantError):
-    """Account has no Irrisense (WRX / WGX / WCX) devices."""
+    """Account has no Irrisense (WR / WG / WC / WL) devices."""

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -20,8 +20,9 @@ API_ENDPOINTS: Final = {
 }
 
 # Irrisense serial prefixes. `WRX` is the original/online-store SKU; `WGX` is
-# the big-box-retail variant (e.g. Costco). Both speak the same wire protocol.
-IRRISENSE_SERIAL_PREFIXES: Final = ("WRX", "WGX")
+# the big-box-retail variant (e.g. Costco); `WCX` is a further retail SKU
+# (Aiper US store). All speak the same wire protocol.
+IRRISENSE_SERIAL_PREFIXES: Final = ("WRX", "WGX", "WCX")
 
 # Model string as written into the S3 zone-map path.
 IRRISENSE_MODEL: Final = "IrriSense_2"

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -19,10 +19,17 @@ API_ENDPOINTS: Final = {
     "asia": "https://apiasia.aiper.com",
 }
 
-# Irrisense serial prefixes. `WRX` is the original/online-store SKU; `WGX` is
-# the big-box-retail variant (e.g. Costco); `WCX` is a further retail SKU
-# (Aiper US store). All speak the same wire protocol.
-IRRISENSE_SERIAL_PREFIXES: Final = ("WRX", "WGX", "WCX")
+# Irrisense serial prefixes. The Aiper app's own device-list classifies
+# IrriSense models by the first **two** letters of the serial:
+#   * `WR` — IrriSense 2 (original / Irrigo WR / IrriSense WR)
+#   * `WG` — IrriSense N2 (big-box retail; Home Depot / Lowe's / Best Buy)
+#   * `WC` — IrriSense 2 Chromatic / IrriSense II (further retail variant)
+#   * `WL` — IrriSense 2 SE
+# The third letter is a production-batch indicator (WRX, WRZ, WGX, WCX, ...);
+# all share the same wire protocol. Matching on the 2-letter family keeps us
+# in sync with the app's behaviour and avoids a new release every time a new
+# batch letter ships.
+IRRISENSE_SERIAL_PREFIXES: Final = ("WR", "WG", "WC", "WL")
 
 # Model string as written into the S3 zone-map path.
 IRRISENSE_MODEL: Final = "IrriSense_2"

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WCX serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX) devices were found on this account.",
+      "no_devices": "No Irrisense (WRX / WGX / WCX) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WCX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only IrriSense devices (WR / WG / WC / WL serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX / WCX) devices were found on this account.",
+      "no_devices": "No IrriSense (WR / WG / WC / WL) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WCX serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX) devices were found on this account.",
+      "no_devices": "No Irrisense (WRX / WGX / WCX) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WCX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only IrriSense devices (WR / WG / WC / WL serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX / WCX) devices were found on this account.",
+      "no_devices": "No IrriSense (WR / WG / WC / WL) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {


### PR DESCRIPTION
IrriSense 2 units sold under SKU variants whose serial does not start with `WRX` or `WGX` are filtered out by the device-list check and the config flow reports "no devices found", even though the devices speak the same wire protocol this integration already supports. So far this has surfaced as two distinct production-batch letters – `WCX` (reported and live-verified by @scottslinkard in #20) and `WRZ` (reported by @Beagle2002 in the same thread).

Looking at how the Aiper app itself classifies devices, the model lookup is done on the **first two letters** of the serial, with four IrriSense families:

| Prefix | Models marketed under it |
|---|---|
| `WR` | IrriSense 2 / Irrigo WR / IrriSense WR (Aiper online store, Amazon) |
| `WG` | IrriSense N2 (big-box retail – Home Depot, Lowe's, Best Buy) |
| `WC` | IrriSense 2 Chromatic / IrriSense II (further retail variant) |
| `WL` | IrriSense 2 SE |

The third letter (`X`, `Z`, …) is a production-batch indicator; all four families share the same wire protocol. Matching on the 2-letter family instead of explicit 3-letter prefixes:

- keeps this integration's accept-list in sync with the app's own behaviour,
- covers `WRX` and `WRZ` under a single rule,
- closes the per-batch follow-up cycle (`WRX → WGX → WCX → WRZ → …`) that would otherwise need a new release each time a batch letter ships,
- is identical in scope to the WCX-only commit (5 files), just with a slightly fuller comment.

This PR:

- `const.py`: `IRRISENSE_SERIAL_PREFIXES = ("WR", "WG", "WC", "WL")` plus a comment that records the family→model mapping
- `__init__.py`: "no devices found" warning log
- `config_flow.py`: comment + `NoIrrisenseDevices` docstring
- `strings.json` and `translations/en.json`: setup description + `no_devices` error

Reports + diagnoses by @scottslinkard (WCX) and @Beagle2002 (WRZ) in #20.

Closes #20.
