### PR TITLE
Remove stale water_pressure_kpa chip from dashboard examples

### DIFF
--- a/examples/dashboard-dual-device-alternative.yaml
+++ b/examples/dashboard-dual-device-alternative.yaml
@@ -303,13 +303,6 @@ views:
                             color: #f0f9ff !important;
                             backdrop-filter: blur(8px);
                           }
-                    - type: template
-                      icon: mdi:gauge
-                      icon_color: cyan
-                      content: |-
-                        {% set p = state_attr('sensor.irrisense_front_lawn_active_zone', 'water_pressure_kpa') | float(0) %}
-                        {{ p | round(0) | int }} kPa
-                      card_mod: *chip_style
                     # PASS chip — shows current coverage pass, 1-indexed
                     # (repair_layer is 0-indexed on the wire). No "of M";
                     # total-pass estimation is unreliable. Dash when not
@@ -1110,13 +1103,6 @@ views:
                             color: #f0fdf4 !important;
                             backdrop-filter: blur(8px);
                           }
-                    - type: template
-                      icon: mdi:gauge
-                      icon_color: green
-                      content: |-
-                        {% set p = state_attr('sensor.irrisense_back_lawn_active_zone', 'water_pressure_kpa') | float(0) %}
-                        {{ p | round(0) | int }} kPa
-                      card_mod: *chip_style_g
                     # PASS chip — see Front Lawn section for rationale.
                     - type: template
                       icon: mdi:layers-triple

--- a/examples/dashboard-dual-device.yaml
+++ b/examples/dashboard-dual-device.yaml
@@ -253,13 +253,6 @@ views:
                             backdrop-filter: blur(8px);
                           }
                     - type: template
-                      icon: mdi:gauge
-                      icon_color: cyan
-                      content: |-
-                        {% set p = state_attr('sensor.irrisense_front_lawn_active_zone', 'water_pressure_kpa') | float(0) %}
-                        {{ p | round(0) | int }} kPa
-                      card_mod: *chip_style
-                    - type: template
                       icon: mdi:layers-triple
                       icon_color: cyan
                       content: |-
@@ -1009,13 +1002,6 @@ views:
                             color: #f0fdf4 !important;
                             backdrop-filter: blur(8px);
                           }
-                    - type: template
-                      icon: mdi:gauge
-                      icon_color: green
-                      content: |-
-                        {% set p = state_attr('sensor.irrisense_back_lawn_active_zone', 'water_pressure_kpa') | float(0) %}
-                        {{ p | round(0) | int }} kPa
-                      card_mod: *chip_style_g
                     - type: template
                       icon: mdi:layers-triple
                       icon_color: green

--- a/examples/dashboard-single-device.yaml
+++ b/examples/dashboard-single-device.yaml
@@ -282,13 +282,6 @@ views:
                             color: #f0f9ff !important;
                             backdrop-filter: blur(8px);
                           }
-                    - type: template
-                      icon: mdi:gauge
-                      icon_color: cyan
-                      content: |-
-                        {% set p = state_attr('sensor.irrisense_garden_active_zone', 'water_pressure_kpa') | float(0) %}
-                        {{ p | round(0) | int }} kPa
-                      card_mod: *chip_style
                     # PASS chip — shows current coverage pass, 1-indexed
                     # (repair_layer is 0-indexed on the wire). No "of M";
                     # total-pass estimation is unreliable. Dash when not


### PR DESCRIPTION
The dashboard examples each render a pressure chip that reads `water_pressure_kpa` from the active-zone sensor. That attribute was removed in 0.3.0 (#16, alongside the `water_pressure` sensor), so the chip now always shows `0 kPa` via its `float(0)` fallback, which is misleading.

This removes the pressure chip from all three examples (one in single-device, two each in the dual-device files). The surrounding chips (dose, pass, timer) and the `chip_style` / `chip_style_g` card-mod anchors are unchanged.
