### PR TITLE
fix: send full payloads so writable switches actually apply

### DIFF
--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -774,14 +774,13 @@ class IrrisenseApi:
         return self._wr_write("/wr/updatePesticideReminderSetting", body)
 
     def set_drainage_reminder(self, sn: str, enabled: bool) -> bool:
-        """Drainage reminder lives under `updateTaskReminderSetting` in the
-        mobile app (shared endpoint toggles all four), but we also try a
-        dedicated endpoint first in case the backend exposes one.
+        """Toggle the drainage reminder.
+
+        The dedicated `/wr/updateDrainageReminderSetting` endpoint works (the
+        write is reflected by `getReminderSetting`). The `updateTaskReminderSetting`
+        call is a defensive fallback for a backend variant that lacks it.
         """
         body = {"sn": sn, "drainageReminder": 1 if enabled else 0}
-        # No known dedicated endpoint yet — send as a field update on the
-        # generic reminder setter if it exists; otherwise fall back to the
-        # generic task-reminder endpoint.
         if self._wr_write("/wr/updateDrainageReminderSetting", body):
             return True
         return self._wr_write("/wr/updateTaskReminderSetting", body)

--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -543,6 +543,30 @@ class IrrisenseApi:
             _LOGGER.debug("WR call %s error: %s", path, err)
         return None
 
+    def _wr_write(self, path: str, body: dict | None = None) -> bool:
+        """POST to a /wr/... write endpoint and report success.
+
+        Unlike :meth:`_wr`, success is the response status (``_is_success``),
+        NOT the presence of a ``data`` payload: the update endpoints answer a
+        successful write with ``{"code": "200", "successful": true}`` and no
+        ``data`` field, so keying success off ``data`` would treat every
+        successful write as a failure.
+        """
+        try:
+            payload = self._call_encrypted("POST", path, body or {})
+            if self._is_success(payload):
+                return True
+            _LOGGER.debug(
+                "WR write %s not successful: code=%s msg=%s body=%s",
+                path,
+                payload.get("code") if isinstance(payload, dict) else None,
+                (payload.get("msg") or payload.get("message")) if isinstance(payload, dict) else None,
+                body,
+            )
+        except Exception as err:
+            _LOGGER.debug("WR write %s error: %s", path, err)
+        return False
+
     # -- Reads --
     def get_wr_equipment_info(self, sn: str) -> dict | None:
         """Irrisense-specific status (firmware, battery, active zone, etc.)."""
@@ -708,13 +732,24 @@ class IrrisenseApi:
             return None
 
     # -- Writes --
-    def set_schedule_enabled(self, sn: str, task_ids: list[int], enabled: bool) -> bool:
-        body = {"sn": sn, "taskIds": task_ids, "enabled": 1 if enabled else 0}
-        return self._wr("/wr/batchUpdateWrWateringTaskEnabledV2", body) is not None
+    def update_watering_task(self, sn: str, task: dict[str, Any]) -> bool:
+        """Enable/disable (or otherwise update) a scheduled watering task.
+
+        The backend has no partial enable-toggle: a stripped
+        ``{sn, taskIds, enabled}`` body to ``batchUpdateWrWateringTaskEnabledV2``
+        is rejected with code 6002 ("required fields missing"). The working
+        path is ``updateWateringTaskV2`` with the FULL task object (the caller
+        flips the ``enabled`` field on the task it already holds).
+        """
+        body = {"sn": sn, **task}
+        return self._wr_write("/wr/updateWateringTaskV2", body)
 
     def set_watering_setting(self, sn: str, settings: dict[str, Any]) -> bool:
+        # `updateWateringSetting` requires the FULL setting object; a partial
+        # body is rejected with code 6002. The coordinator merges the changed
+        # keys onto the last-known setting snapshot before calling this.
         body = {"sn": sn, **settings}
-        return self._wr("/wr/updateWateringSetting", body) is not None
+        return self._wr_write("/wr/updateWateringSetting", body)
 
     def set_nozzle_type(self, sn: str, nozzle_type: int) -> bool:
         # The `/wr/updateNozzleTypeSetting` REST endpoint uses a 1-indexed
@@ -724,19 +759,19 @@ class IrrisenseApi:
         #     updateNozzleTypeSetting(sn, value == 1 ? 2 : 1)
         server_value = 2 if int(nozzle_type) == 1 else 1
         body = {"sn": sn, "nozzleType": server_value}
-        return self._wr("/wr/updateNozzleTypeSetting", body) is not None
+        return self._wr_write("/wr/updateNozzleTypeSetting", body)
 
     def set_water_shortage_reminder(self, sn: str, enabled: bool) -> bool:
         body = {"sn": sn, "waterShortageReminder": 1 if enabled else 0}
-        return self._wr("/wr/updateWaterShortageReminderSetting", body) is not None
+        return self._wr_write("/wr/updateWaterShortageReminderSetting", body)
 
     def set_task_reminder(self, sn: str, enabled: bool) -> bool:
         body = {"sn": sn, "taskReminder": 1 if enabled else 0}
-        return self._wr("/wr/updateTaskReminderSetting", body) is not None
+        return self._wr_write("/wr/updateTaskReminderSetting", body)
 
     def set_pesticide_reminder(self, sn: str, enabled: bool) -> bool:
         body = {"sn": sn, "pesticideReminder": 1 if enabled else 0}
-        return self._wr("/wr/updatePesticideReminderSetting", body) is not None
+        return self._wr_write("/wr/updatePesticideReminderSetting", body)
 
     def set_drainage_reminder(self, sn: str, enabled: bool) -> bool:
         """Drainage reminder lives under `updateTaskReminderSetting` in the
@@ -746,11 +781,10 @@ class IrrisenseApi:
         body = {"sn": sn, "drainageReminder": 1 if enabled else 0}
         # No known dedicated endpoint yet — send as a field update on the
         # generic reminder setter if it exists; otherwise fall back to the
-        # watering-setting path (some backends accept reminder keys there).
-        result = self._wr("/wr/updateDrainageReminderSetting", body)
-        if result is None:
-            result = self._wr("/wr/updateTaskReminderSetting", body)
-        return result is not None
+        # generic task-reminder endpoint.
+        if self._wr_write("/wr/updateDrainageReminderSetting", body):
+            return True
+        return self._wr_write("/wr/updateTaskReminderSetting", body)
 
     # ------------------------------------------------------------------ #
     # MQTT — AWS IoT WebSocket (SigV4)

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -650,10 +650,17 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             self._run_watchdog_tasks.pop(sn, None)
 
     async def async_set_schedule_enabled(
-        self, sn: str, task_ids: list[int], enabled: bool
+        self, sn: str, task: dict[str, Any] | None, enabled: bool
     ) -> bool:
+        # The backend rejects a partial enable-toggle; the working path is
+        # `updateWateringTaskV2` with the full task object and the `enabled`
+        # field flipped. The switch passes the task it already holds.
+        if not isinstance(task, dict):
+            _LOGGER.warning("ScheduleSwitch: no task to update for %s", sn)
+            return False
+        body = {**task, "enabled": 1 if enabled else 0}
         ok = await self.hass.async_add_executor_job(
-            self.api.set_schedule_enabled, sn, task_ids, enabled
+            self.api.update_watering_task, sn, body
         )
         if ok:
             # Force a settings refresh on next poll.
@@ -671,8 +678,20 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         return ok
 
     async def async_set_watering_setting(self, sn: str, settings: dict[str, Any]) -> bool:
+        # `updateWateringSetting` requires the full setting object (a partial
+        # body is rejected with code 6002). Merge the changed keys onto the
+        # last-known setting snapshot so untouched fields are preserved. Without
+        # a snapshot (device not polled yet) a partial write would just be
+        # rejected, so fail fast and let the caller surface it.
+        current = (self.data or {}).get(sn, {}).get("setting")
+        if not isinstance(current, dict):
+            _LOGGER.warning(
+                "Cannot update watering setting for %s: no setting snapshot yet", sn
+            )
+            return False
+        body = {**current, **settings}
         ok = await self.hass.async_add_executor_job(
-            self.api.set_watering_setting, sn, settings
+            self.api.set_watering_setting, sn, body
         )
         if ok:
             self._last_settings_fetch.pop(sn, None)

--- a/custom_components/aiper_irrisense/switch.py
+++ b/custom_components/aiper_irrisense/switch.py
@@ -16,6 +16,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -178,10 +179,12 @@ class ScheduleSwitch(IrrisenseEntity, SwitchEntity):
         }
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.async_set_schedule_enabled(self._sn, [self._task_id], True)
+        if not await self.coordinator.async_set_schedule_enabled(self._sn, self._task(), True):
+            raise HomeAssistantError(f"Failed to enable {self._attr_name}")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.async_set_schedule_enabled(self._sn, [self._task_id], False)
+        if not await self.coordinator.async_set_schedule_enabled(self._sn, self._task(), False):
+            raise HomeAssistantError(f"Failed to disable {self._attr_name}")
 
 
 # --------------------------------------------------------------------------- #
@@ -210,13 +213,18 @@ class _SettingSwitch(IrrisenseEntity, SwitchEntity):
         return False
 
     async def _write(self, value: int) -> None:
+        ok = False
         if self._writer == "setting":
-            await self.coordinator.async_set_watering_setting(
+            ok = await self.coordinator.async_set_watering_setting(
                 self._sn, {self._setting_key: value}
             )
         elif self._writer == "reminder":
-            await self.coordinator.async_set_reminder(
+            ok = await self.coordinator.async_set_reminder(
                 self._sn, self._setting_key, bool(value)
+            )
+        if not ok:
+            raise HomeAssistantError(
+                f"Failed to update {self._attr_name or self._setting_key}"
             )
 
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Problem

The rain/wind sensing switches, the reminder switches, and the schedule plan switches all flip back immediately - the cloud write never lands. Investigated against the live API; it is three separate write-path bugs, not one.

## Fixes (each verified against the live cloud API)

1. **Rain / wind sensing** - `updateWateringSetting` only accepts the *full* setting object. A single-key body (`{sn, weatherSensingRain}`) is rejected with code 6002 ("required fields missing"). The coordinator now merges the changed key onto the last-known setting snapshot before writing.
2. **Schedule plans** - the enable/disable toggle used `batchUpdateWrWateringTaskEnabledV2` with a stripped `{sn, taskIds, enabled}` body, also rejected with 6002. Switched to `updateWateringTaskV2` with the full task object and the `enabled` field flipped.
3. **All writes (reminders included)** - the update endpoints answer a successful write with `{code: 200, successful: true}` and no `data` field, so the old `_wr(...) is not None` check treated every successful write as a failure and skipped the optimistic state refresh. Added `_wr_write()`, keyed on the response status, and routed all writes through it.

A genuinely failed write now raises `HomeAssistantError` instead of reverting with no feedback, and a watering-setting write with no cached snapshot fails fast rather than sending a doomed partial body.

## Verification

Live cloud API, real IrriSense 2 account, GET -> write -> GET each time:
- watering: full body `weatherSensingRain` 0->1 returns 200 and the GET reflects 1 (partial body returns 6002); restored.
- reminder: `taskReminder` 0->1->0, each step takes effect (200).
- schedule: real task `enabled` 1->0 via `updateWateringTaskV2` returns 200 and the GET reflects 0 (the old endpoint/body returns 6002); restored.

Fixes #27
