### PR TITLE
feat: add weather entity backed by the Aiper WeatherKit endpoint

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -30,6 +30,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
     Platform.BUTTON,
+    Platform.WEATHER,
 ]
 # Dose lives on the Watering Dose select (label-valued: "3 mm" / "5 min" / ...)
 # and backend mapping happens in button.StartWateringButton.

--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -558,6 +558,23 @@ class IrrisenseApi:
     def get_watering_setting(self, sn: str) -> dict | None:
         return self._wr("/wr/getWateringSettingV2", {"sn": sn})
 
+    def get_weather(self, latitude: float, longitude: float) -> dict | None:
+        """Apple-WeatherKit-proxied forecast. Read-only. Returns parsed
+        {currentWeather, forecastDaily} or None. data arrives as a JSON string."""
+        from .weather_helpers import parse_weather_payload
+
+        raw = self._wr(
+            "/weatherkit/getWeather",
+            {
+                "dataSets": "currentWeather,forecastDaily",
+                "language": "en",
+                "latitude": float(latitude),
+                "longitude": float(longitude),
+                "reverseGeocodingValue": "",
+            },
+        )
+        return parse_weather_payload(raw)
+
     def get_nozzle_type_setting(self, sn: str) -> dict | None:
         return self._wr("/wr/getNozzleTypeSetting", {"sn": sn})
 

--- a/custom_components/aiper_irrisense/config_flow.py
+++ b/custom_components/aiper_irrisense/config_flow.py
@@ -21,10 +21,12 @@ from .const import (
     CONF_POLL_INTERVAL,
     CONF_REGION,
     CONF_REMINDER_REFRESH_HOURS,
+    CONF_WEATHER_REFRESH_HOURS,
     DEFAULT_HISTORY_REFRESH_HOURS,
     DEFAULT_MAP_REFRESH_HOURS,
     DEFAULT_REMINDER_REFRESH_HOURS,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WEATHER_REFRESH_HOURS,
     DOMAIN,
 )
 
@@ -176,6 +178,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_REMINDER_REFRESH_HOURS,
                     default=current.get(CONF_REMINDER_REFRESH_HOURS, DEFAULT_REMINDER_REFRESH_HOURS),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=168)),
+                vol.Optional(
+                    CONF_WEATHER_REFRESH_HOURS,
+                    default=current.get(CONF_WEATHER_REFRESH_HOURS, DEFAULT_WEATHER_REFRESH_HOURS),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1, max=168)),
             }
         )

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -34,6 +34,7 @@ CONF_POLL_INTERVAL: Final = "poll_interval"
 CONF_MAP_REFRESH_HOURS: Final = "map_refresh_hours"
 CONF_HISTORY_REFRESH_HOURS: Final = "history_refresh_hours"
 CONF_REMINDER_REFRESH_HOURS: Final = "reminder_refresh_hours"
+CONF_WEATHER_REFRESH_HOURS: Final = "weather_refresh_hours"
 
 DEFAULT_SCAN_INTERVAL: Final = 120  # seconds
 DEFAULT_FAST_SCAN_INTERVAL: Final = 5  # seconds during an active watering event
@@ -41,6 +42,7 @@ DEFAULT_FAST_WINDOW_SECONDS: Final = 60
 DEFAULT_MAP_REFRESH_HOURS: Final = 6
 DEFAULT_HISTORY_REFRESH_HOURS: Final = 6
 DEFAULT_REMINDER_REFRESH_HOURS: Final = 24
+DEFAULT_WEATHER_REFRESH_HOURS: Final = 1
 
 # ---- MQTT topic patterns --------------------------------------------------
 # Same AWS IoT infrastructure as the pool cleaner integration — the Irrisense

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -36,12 +36,14 @@ from .const import (
     CONF_MAP_REFRESH_HOURS,
     CONF_POLL_INTERVAL,
     CONF_REMINDER_REFRESH_HOURS,
+    CONF_WEATHER_REFRESH_HOURS,
     DEFAULT_FAST_SCAN_INTERVAL,
     DEFAULT_FAST_WINDOW_SECONDS,
     DEFAULT_HISTORY_REFRESH_HOURS,
     DEFAULT_MAP_REFRESH_HOURS,
     DEFAULT_REMINDER_REFRESH_HOURS,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WEATHER_REFRESH_HOURS,
     DOMAIN,
     POINT_TIME_LOW,
     POINT_TIME_PRESETS,
@@ -160,6 +162,11 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._last_history_fetch: dict[str, float] = {}
         self._last_reminder_fetch: dict[str, float] = {}
         self._last_settings_fetch: dict[str, float] = {}
+        self._last_weather_fetch: float = 0.0
+        # Per-SN parsed WeatherKit payloads (sn -> {currentWeather, forecastDaily}).
+        # One entity per device reads its own SN; the fetch dedups by coordinate
+        # so identical coords (all devices at HA home today) cost ONE API call.
+        self._weather: dict[str, dict[str, Any]] = {}
 
         # User's current Dashboard selection (controls card).
         # Populated by the ZoneSelect / DoseSelect entities; read by the
@@ -209,6 +216,7 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._map_refresh = int(opts.get(CONF_MAP_REFRESH_HOURS, DEFAULT_MAP_REFRESH_HOURS)) * 3600
         self._history_refresh = int(opts.get(CONF_HISTORY_REFRESH_HOURS, DEFAULT_HISTORY_REFRESH_HOURS)) * 3600
         self._reminder_refresh = int(opts.get(CONF_REMINDER_REFRESH_HOURS, DEFAULT_REMINDER_REFRESH_HOURS)) * 3600
+        self._weather_refresh = int(opts.get(CONF_WEATHER_REFRESH_HOURS, DEFAULT_WEATHER_REFRESH_HOURS)) * 3600
 
     # ------------------------------------------------------------------ #
     # Public helpers
@@ -218,6 +226,55 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     def devices(self) -> list[dict]:
         """Return the list of discovered Irrisense device dicts."""
         return list(self.api._devices.values())  # noqa: SLF001
+
+    def weather_for(self, sn: str) -> dict[str, Any] | None:
+        """Latest parsed WeatherKit payload for one device, or None."""
+        return self._weather.get(sn)
+
+    def _resolve_coords(self, sn: str) -> tuple[float, float] | None:
+        """Coordinates to fetch weather for `sn`. The single per-device seam.
+
+        Today every device uses HA's home coordinates. Per-device Aiper
+        location can be wired in here later (look up the device's stored
+        lat/lng, fall back to home) without touching the entity layer.
+        """
+        from .weather_helpers import resolve_coords
+
+        return resolve_coords(self.hass.config.latitude, self.hass.config.longitude)
+
+    async def _refresh_weather(self) -> None:
+        """Fetch per-device weather at most every `_weather_refresh`. Fully
+        failure-isolated: any error is swallowed and last-good is kept so
+        watering is never affected by a weather rate-limit. Dedups by
+        coordinate — devices sharing coords cost a single API call."""
+        try:
+            now = time.time()
+            if self._weather and now - self._last_weather_fetch < self._weather_refresh:
+                return
+            # Group devices by their resolved coordinate so identical coords
+            # (all at HA home today) are fetched once and shared.
+            coord_to_sns: dict[tuple[float, float], list[str]] = {}
+            for dev in self.devices:
+                sn = dev.get("sn")
+                if not sn:
+                    continue
+                coords = self._resolve_coords(sn)
+                if coords is None:
+                    continue
+                coord_to_sns.setdefault(coords, []).append(sn)
+            fetched_any = False
+            for coords, sns in coord_to_sns.items():
+                w = await self.hass.async_add_executor_job(
+                    self.api.get_weather, coords[0], coords[1]
+                )
+                if isinstance(w, dict):
+                    for sn in sns:
+                        self._weather[sn] = w
+                    fetched_any = True
+            if fetched_any:
+                self._last_weather_fetch = now
+        except Exception as err:  # noqa: BLE001 - weather must never break the refresh
+            _LOGGER.debug("weather refresh failed (will retry next poll): %s", err)
 
     def get_device_data(self, sn: str) -> dict[str, Any]:
         return self._data.setdefault(sn, {})
@@ -256,6 +313,8 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                     _LOGGER.debug("Skipping disabled device %s in refresh", sn)
                     continue
                 await self._refresh_device(sn, dev)
+
+            await self._refresh_weather()
 
             return self._data
         except Exception as err:

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -38,7 +38,8 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "weather_refresh_hours": "Weather refresh (hours)"
         }
       }
     }

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -38,7 +38,8 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "weather_refresh_hours": "Weather refresh (hours)"
         }
       }
     }

--- a/custom_components/aiper_irrisense/weather.py
+++ b/custom_components/aiper_irrisense/weather.py
@@ -1,0 +1,131 @@
+"""Weather platform for Aiper Irrisense 2 – Apple-WeatherKit-proxied cloud data.
+
+One weather entity per device, driven by HA home coordinates today (the
+coordinator's per-device coordinate seam lets per-device Aiper location be
+wired in later with no entity change). Read-only. All field mapping lives in
+weather_helpers (tested).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.weather import (
+    Forecast,
+    WeatherEntity,
+    WeatherEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfLength,
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import IrrisenseCoordinator
+from .entity import IrrisenseEntity
+from .weather_helpers import current_attrs, daily_forecast
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: IrrisenseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[IrrisenseWeather] = []
+    for dev in coordinator.devices:
+        sn = dev.get("sn")
+        if sn:
+            entities.append(IrrisenseWeather(coordinator, sn))
+    async_add_entities(entities)
+
+
+class IrrisenseWeather(IrrisenseEntity, WeatherEntity):
+    """Per-device weather via the Aiper WeatherKit proxy.
+
+    One entity per device. Today every device resolves to HA's home
+    coordinates (so all show the same data, fetched once); the coordinate
+    source is per-device in the coordinator, so per-device Aiper location
+    can be wired in later with no entity change."""
+
+    _attr_supported_features = WeatherEntityFeature.FORECAST_DAILY
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_native_pressure_unit = UnitOfPressure.MBAR
+    _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
+    _attr_native_visibility_unit = UnitOfLength.METERS
+    _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "weather")
+        self._attr_name = "Weather"
+
+    @property
+    def _weather(self) -> dict[str, Any]:
+        return self.coordinator.weather_for(self._sn) or {}
+
+    @property
+    def _current(self) -> dict[str, Any]:
+        return self._weather.get("currentWeather") or {}
+
+    @property
+    def _attrs(self) -> dict[str, Any]:
+        return current_attrs(self._current)
+
+    @property
+    def available(self) -> bool:
+        return bool(self.coordinator.last_update_success) and bool(self._weather)
+
+    @property
+    def condition(self) -> str | None:
+        return self._attrs["condition"]
+
+    @property
+    def native_temperature(self) -> float | None:
+        return self._attrs["temperature"]
+
+    @property
+    def native_apparent_temperature(self) -> float | None:
+        return self._attrs["apparent_temperature"]
+
+    @property
+    def native_dew_point(self) -> float | None:
+        return self._attrs["dew_point"]
+
+    @property
+    def humidity(self) -> float | None:
+        return self._attrs["humidity"]
+
+    @property
+    def native_pressure(self) -> float | None:
+        return self._attrs["pressure"]
+
+    @property
+    def native_wind_speed(self) -> float | None:
+        return self._attrs["wind_speed"]
+
+    @property
+    def native_wind_gust_speed(self) -> float | None:
+        return self._attrs["wind_gust_speed"]
+
+    @property
+    def wind_bearing(self) -> float | None:
+        return self._attrs["wind_bearing"]
+
+    @property
+    def uv_index(self) -> float | None:
+        return self._attrs["uv_index"]
+
+    @property
+    def native_visibility(self) -> float | None:
+        return self._attrs["visibility"]
+
+    @property
+    def cloud_coverage(self) -> float | None:
+        return self._attrs["cloud_coverage"]
+
+    async def async_forecast_daily(self) -> list[Forecast] | None:
+        days = (self._weather.get("forecastDaily") or {}).get("days") or []
+        return [Forecast(**item) for item in daily_forecast(days)]

--- a/custom_components/aiper_irrisense/weather_helpers.py
+++ b/custom_components/aiper_irrisense/weather_helpers.py
@@ -1,0 +1,134 @@
+"""Pure (HA-free) helpers for the Aiper weather entity. Unit-tested with stdlib pytest."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_weather_payload(raw: str | dict | None) -> dict | None:
+    """`/weatherkit/getWeather` returns its payload as a JSON *string* in `data`.
+
+    Accept the string (parse it), a pre-parsed dict (passthrough), or None.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            obj = json.loads(raw)
+        except (ValueError, TypeError):
+            _LOGGER.debug("weather: data not JSON: %.120s", raw)
+            return None
+        return obj if isinstance(obj, dict) else None
+    return None
+
+
+# Apple WeatherKit conditionCode -> HA condition. daylight picks sunny/clear-night.
+# Covers the common set; unknown codes log once and fall back to "cloudy".
+_CONDITION_MAP: dict[str, str] = {
+    "PartlyCloudy": "partlycloudy",
+    "MostlyCloudy": "cloudy",
+    "Cloudy": "cloudy",
+    "Foggy": "fog",
+    "Haze": "fog",
+    "Smoky": "fog",
+    "Breezy": "windy",
+    "Windy": "windy",
+    "Drizzle": "rainy",
+    "Rain": "rainy",
+    "Showers": "rainy",
+    "Precipitation": "rainy",
+    "HeavyRain": "pouring",
+    "Thunderstorms": "lightning-rainy",
+    "IsolatedThunderstorms": "lightning-rainy",
+    "ScatteredThunderstorms": "lightning-rainy",
+    "StrongStorms": "lightning-rainy",
+    "Flurries": "snowy",
+    "Snow": "snowy",
+    "HeavySnow": "snowy",
+    "SnowShowers": "snowy",
+    "BlowingSnow": "snowy",
+    "Blizzard": "snowy",
+    "Sleet": "snowy-rainy",
+    "FreezingRain": "snowy-rainy",
+    "FreezingDrizzle": "snowy-rainy",
+    "WintryMix": "snowy-rainy",
+    "Hail": "hail",
+    "Hot": "exceptional",
+    "Frigid": "exceptional",
+    "Hurricane": "exceptional",
+    "TropicalStorm": "exceptional",
+}
+
+_seen_unknown: set[str] = set()
+
+
+def ha_condition(condition_code: str | None, daylight: bool) -> str:
+    if condition_code in ("Clear", "MostlyClear"):
+        return "sunny" if daylight else "clear-night"
+    mapped = _CONDITION_MAP.get(condition_code or "")
+    if mapped is None:
+        if condition_code and condition_code not in _seen_unknown:
+            _seen_unknown.add(condition_code)
+            _LOGGER.warning("Unmapped WeatherKit conditionCode %r -> cloudy", condition_code)
+        return "cloudy"
+    return mapped
+
+
+def _pct(value: Any) -> float | None:
+    """WeatherKit 0-1 fraction -> HA percent."""
+    if isinstance(value, (int, float)):
+        return round(float(value) * 100, 1)
+    return None
+
+
+def current_attrs(current: dict) -> dict:
+    c = current or {}
+    return {
+        "temperature": c.get("temperature"),
+        "apparent_temperature": c.get("temperatureApparent"),
+        "dew_point": c.get("temperatureDewPoint"),
+        "humidity": _pct(c.get("humidity")),
+        "pressure": c.get("pressure"),
+        "wind_speed": c.get("windSpeed"),
+        "wind_gust_speed": c.get("windGust"),
+        "wind_bearing": c.get("windDirection"),
+        "uv_index": c.get("uvIndex"),
+        "visibility": c.get("visibility"),
+        "cloud_coverage": _pct(c.get("cloudCover")),
+        "condition": ha_condition(c.get("conditionCode"), bool(c.get("daylight", True))),
+    }
+
+
+def daily_forecast(days: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for d in days or []:
+        if not isinstance(d, dict):
+            continue
+        out.append(
+            {
+                "datetime": d.get("forecastStart"),
+                "condition": ha_condition(d.get("conditionCode"), daylight=True),
+                "native_temperature": d.get("temperatureMax"),
+                "native_templow": d.get("temperatureMin"),
+                "precipitation_probability": _pct(d.get("precipitationChance")),
+                "native_precipitation": d.get("precipitationAmount"),
+                "uv_index": d.get("maxUvIndex"),
+                "native_wind_speed": d.get("windSpeedMax"),
+            }
+        )
+    return out
+
+
+def resolve_coords(
+    latitude: float | None, longitude: float | None
+) -> tuple[float, float] | None:
+    if latitude is None or longitude is None:
+        return None
+    if latitude == 0 and longitude == 0:
+        return None
+    return (float(latitude), float(longitude))

--- a/tests/fixtures/weatherkit_sample.json
+++ b/tests/fixtures/weatherkit_sample.json
@@ -1,0 +1,54 @@
+{
+  "currentWeather": {
+    "asOf": "2026-06-24T18:24:33Z",
+    "conditionCode": "PartlyCloudy",
+    "daylight": false,
+    "humidity": 0.85,
+    "cloudCover": 0.53,
+    "precipitationIntensity": 0.0,
+    "pressure": 1014.78,
+    "pressureTrend": "rising",
+    "temperature": 23.29,
+    "temperatureApparent": 22.58,
+    "temperatureDewPoint": 20.62,
+    "uvIndex": 0,
+    "visibility": 17181.62,
+    "windDirection": 133,
+    "windGust": 18.82,
+    "windSpeed": 14.3
+  },
+  "forecastDaily": {
+    "days": [
+      {
+        "forecastStart": "2026-06-23T22:00:00Z",
+        "forecastEnd": "2026-06-24T22:00:00Z",
+        "conditionCode": "MostlyClear",
+        "maxUvIndex": 7,
+        "precipitationAmount": 0.0,
+        "precipitationChance": 0.43,
+        "precipitationType": "clear",
+        "snowfallAmount": 0.0,
+        "temperatureMax": 24.1,
+        "temperatureMin": 13.2,
+        "windSpeedAvg": 9.0,
+        "windSpeedMax": 18.0,
+        "windGustSpeedMax": 30.0
+      },
+      {
+        "forecastStart": "2026-06-24T22:00:00Z",
+        "forecastEnd": "2026-06-25T22:00:00Z",
+        "conditionCode": "Rain",
+        "maxUvIndex": 5,
+        "precipitationAmount": 3.4,
+        "precipitationChance": 0.8,
+        "precipitationType": "rain",
+        "snowfallAmount": 0.0,
+        "temperatureMax": 19.0,
+        "temperatureMin": 12.0,
+        "windSpeedAvg": 12.0,
+        "windSpeedMax": 22.0,
+        "windGustSpeedMax": 40.0
+      }
+    ]
+  }
+}

--- a/tests/test_weather_helpers.py
+++ b/tests/test_weather_helpers.py
@@ -1,0 +1,81 @@
+import importlib.util
+import json
+import pathlib
+
+# Load weather_helpers DIRECTLY by file path. A normal
+# `from custom_components.aiper_irrisense import weather_helpers` would execute
+# the package __init__.py, which imports homeassistant (not installed in this
+# test env). weather_helpers itself is pure stdlib, so file-loading it is clean.
+_WH_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "custom_components" / "aiper_irrisense" / "weather_helpers.py"
+)
+_spec = importlib.util.spec_from_file_location("weather_helpers", _WH_PATH)
+wh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wh)
+
+FIX = pathlib.Path(__file__).parent / "fixtures" / "weatherkit_sample.json"
+SAMPLE = FIX.read_text()
+
+
+def test_parse_weather_payload_from_json_string():
+    # WeatherKit returns the payload as a JSON *string* in data
+    out = wh.parse_weather_payload(SAMPLE)
+    assert out is not None
+    assert out["currentWeather"]["temperature"] == 23.29
+    assert len(out["forecastDaily"]["days"]) == 2
+
+
+def test_parse_weather_payload_passthrough_dict():
+    d = json.loads(SAMPLE)
+    assert wh.parse_weather_payload(d) == d
+
+
+def test_parse_weather_payload_garbage_returns_none():
+    assert wh.parse_weather_payload("not json") is None
+    assert wh.parse_weather_payload(None) is None
+
+
+def test_ha_condition_known_codes():
+    assert wh.ha_condition("Clear", daylight=True) == "sunny"
+    assert wh.ha_condition("Clear", daylight=False) == "clear-night"
+    assert wh.ha_condition("PartlyCloudy", daylight=True) == "partlycloudy"
+    assert wh.ha_condition("Rain", daylight=True) == "rainy"
+    assert wh.ha_condition("HeavyRain", daylight=True) == "pouring"
+    assert wh.ha_condition("Thunderstorms", daylight=True) == "lightning-rainy"
+    assert wh.ha_condition("Snow", daylight=True) == "snowy"
+
+
+def test_ha_condition_unknown_falls_back():
+    assert wh.ha_condition("SomeNewAppleCode", daylight=True) == "cloudy"
+    assert wh.ha_condition(None, daylight=True) == "cloudy"
+
+
+def test_current_attrs_scales_fractions():
+    cur = json.loads(SAMPLE)["currentWeather"]
+    a = wh.current_attrs(cur)
+    assert a["temperature"] == 23.29
+    assert a["humidity"] == 85.0          # 0.85 -> %
+    assert a["cloud_coverage"] == 53.0    # 0.53 -> %
+    assert a["wind_bearing"] == 133
+    assert a["condition"] == "partlycloudy"  # PartlyCloudy -> partlycloudy
+
+
+def test_daily_forecast_shape():
+    days = json.loads(SAMPLE)["forecastDaily"]["days"]
+    fc = wh.daily_forecast(days)
+    assert len(fc) == 2
+    d0 = fc[0]
+    assert d0["datetime"] == "2026-06-23T22:00:00Z"
+    assert d0["native_temperature"] == 24.1
+    assert d0["native_templow"] == 13.2
+    assert d0["precipitation_probability"] == 43.0   # 0.43 -> %
+    assert d0["native_precipitation"] == 0.0
+    assert fc[1]["condition"] == "rainy"
+    assert fc[1]["native_precipitation"] == 3.4
+
+
+def test_resolve_coords():
+    assert wh.resolve_coords(53.55, 9.99) == (53.55, 9.99)
+    assert wh.resolve_coords(None, 9.99) is None
+    assert wh.resolve_coords(0.0, 0.0) is None   # unset HA home -> skip


### PR DESCRIPTION
## Summary

Adds a native Home Assistant `weather` entity per device, backed by the cloud's `/weatherkit/getWeather` endpoint (the same Apple-WeatherKit-sourced data the app shows). It surfaces current conditions plus a 10-day daily forecast, so the garden's weather is available for automations and dashboards alongside the existing entities.

## What it does

- One `weather` entity per device, driven by Home Assistant's configured home coordinates (`hass.config.latitude/longitude`).
- Current conditions: temperature, apparent temperature, dew point, humidity, pressure, wind speed / gust / bearing, UV index, visibility, cloud coverage, condition.
- 10-day daily forecast via `async_forecast_daily` (`FORECAST_DAILY`).
- Apple WeatherKit `conditionCode` mapped to HA conditions, with the `daylight` flag choosing `sunny` vs `clear-night` and a logged fallback for any unmapped code.

## Design notes

- **Read-only and isolated:** the weather fetch is fully wrapped, so a weather error or rate-limit can never fail the device refresh or the MQTT control path — watering keeps working regardless.
- **Cheap:** fetched at most once per hour (configurable via a new `weather_refresh_hours` option), and deduplicated by coordinate so devices at the same location share a single upstream call.
- **Per-device coordinate seam:** coordinates resolve through a single per-device function (home coordinates today), so a per-device location can be wired in later with no entity change.
- Field mapping lives in a pure, unit-tested helper module (`weather_helpers.py`); the entity is a thin wrapper over it.

## Testing

- Unit tests for the payload parser, condition mapping, current-attribute scaling, forecast building, and coordinate resolution (`tests/test_weather_helpers.py`, using a captured real payload fixture).
- Verified live against a two-device account: both per-device weather entities populate with current conditions and the full 10-day forecast, with identical data served from a single coordinate-deduplicated upstream call (same refresh cycle). Condition codes map correctly (`sunny` / `cloudy` / `rainy` / `lightning-rainy` observed), the day/night switch works (`sunny` → `clear-night`), and no unmapped-condition warnings appear.

## Notes

- Coordinates use the Home Assistant home location rather than a per-device location: the weather endpoint takes caller-supplied lat/lng, and per-device location is a straightforward follow-up if there's interest.
