### PR TITLE
Resilience: tolerate getEquipment 402 by persisting the device list

### DIFF
--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import logging
 import random
 import threading
@@ -206,6 +207,13 @@ class IrrisenseApi:
         # Device cache
         self._devices: dict[str, dict] = {}
         self._device_zone_id_by_sn: dict[str, str] = {}
+        # --- resilience patch: persist device list so a 402 on
+        #     getEquipment at startup/reload doesn't leave entities
+        #     unavailable; reuse the on-disk list instead. ---
+        self._devices_cache_file = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "aiper_devices_cache.json")
+        self._load_devices_cache()
 
         # MQTT subscription callbacks
         self._shadow_callbacks: dict[str, list[Callable]] = {}
@@ -467,13 +475,35 @@ class IrrisenseApi:
     # Device discovery / shared endpoints
     # ------------------------------------------------------------------ #
 
+    def _load_devices_cache(self) -> None:
+        try:
+            with open(self._devices_cache_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            devs = data.get("devices") or {}
+            if isinstance(devs, dict) and devs:
+                self._devices.update(devs)
+                self._device_zone_id_by_sn.update(data.get("zone_ids") or {})
+                _LOGGER.info("Loaded %d cached Irrisense device(s)", len(devs))
+        except FileNotFoundError:
+            pass
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Could not load device cache: %s", err)
+
+    def _save_devices_cache(self) -> None:
+        try:
+            with open(self._devices_cache_file, "w", encoding="utf-8") as f:
+                json.dump({"devices": self._devices,
+                           "zone_ids": self._device_zone_id_by_sn}, f)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Could not save device cache: %s", err)
+
     def get_devices(self) -> list[dict]:
         """List all devices on the account and filter for Irrisense units."""
         try:
             payload = self._call_encrypted("POST", "/equipment/getEquipment", {})
             if not self._is_success(payload):
-                _LOGGER.warning("get_devices failed: %s", payload.get("code"))
-                return []
+                _LOGGER.warning("get_devices failed: %s — using cached list (%d)", payload.get("code"), len(self._devices))
+                return list(self._devices.values())
 
             devices = payload.get("data", []) or []
             if isinstance(devices, dict):
@@ -493,10 +523,15 @@ class IrrisenseApi:
                 if isinstance(zid, str) and zid:
                     self._device_zone_id_by_sn[sn] = zid
                 out.append(device)
+            if out:
+                self._save_devices_cache()
+                return out
+            if self._devices:
+                return list(self._devices.values())
             return out
         except Exception as err:
-            _LOGGER.error("Failed to get devices: %s", err)
-            return []
+            _LOGGER.error("Failed to get devices: %s — using cached list (%d)", err, len(self._devices))
+            return list(self._devices.values())
 
     def get_equipment_info(self, sn: str) -> dict | None:
         """Shared `/equipment/getEquipmentInfo` — generic device metadata."""

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -239,9 +239,14 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             self.update_interval = self._base_interval
 
         try:
-            # Refresh device list on every pass (cheap; once a day would be
-            # enough, but it also catches new devices being added).
-            await self.hass.async_add_executor_job(self.api.get_devices)
+            # Resilience patch: refresh the device list only every ~10 min
+            # instead of every poll, so an intermittent getEquipment 402
+            # doesn't drop all entities (get_devices falls back to its
+            # on-disk cache on 402).
+            _now = time.time()
+            if (_now - getattr(self, "_last_devlist_refresh", 0.0)) > 600:
+                self._last_devlist_refresh = _now
+                await self.hass.async_add_executor_job(self.api.get_devices)
 
             device_registry = dr.async_get(self.hass)
             for dev in self.devices:


### PR DESCRIPTION
## Problem

On some accounts the cloud endpoint `POST /equipment/getEquipment` returns **HTTP 402** (intermittently or persistently). Because the coordinator refreshes the device list on **every** poll *and* at setup, a 402 currently makes `get_devices()` return `[]`, which leaves the coordinator with **zero devices** → **all entities go `unavailable`**.

This is most visible on a **reload/restart**: while the integration runs long enough to have populated the in-memory `_devices` cache, telemetry keeps working; but after a restart the cache is empty, the first `getEquipment` 402s, and the integration never recovers (everything `unavailable`). MQTT control + `getEquipmentInfo` telemetry actually work fine — only the device *list* call is failing.

## Fix (small, surgical)

**`api.py`**
- Persist `_devices` / `_device_zone_id_by_sn` to an on-disk JSON cache (`aiper_devices_cache.json` in the config dir). Saved on every successful `get_devices()`, loaded in `__init__`.
- `get_devices()` now returns the **cached list** instead of `[]` when `getEquipment` fails (402 / exception / empty payload). So a known device set survives a cloud hiccup, and `getEquipmentInfo` + control keep working.

**`coordinator.py`**
- Refresh the device list at most **every ~10 min** instead of on every poll, so an intermittent 402 no longer risks dropping everything between full refreshes.

Net effect: the integration stays **available and controllable** even while `getEquipment` is 402-ing, and **survives restarts/reloads**.

## Testing

- HA 2026.6, integration v0.3.0, account whose `getEquipment` 402s.
- Before: every reload/restart → all `irrisense`/`jardin` entities `unavailable`.
- After: restart → entities `available`, `online=on`, telemetry flowing, switch/command writes apply (verified `rain_sensing` toggle + an active watering cycle). Survives `Reload` of the config entry.

## Notes / open to feedback

- The cache path is derived from `__file__` (config dir). If you'd rather use `hass.helpers.storage.Store` or `hass.config.path(...)`, I'm happy to rework it — `IrrisenseApi` is currently `hass`-agnostic (sync client), hence the plain-file approach.
- Could also gate the on-disk cache behind a successful first discovery only (already effectively the case).
- Doesn't touch the cloud-side limitations (single active session, latency) — only stops a `getEquipment` 402 from taking the whole integration down.