### PR TITLE
fix: retry zone-map fetch after a short backoff instead of the full interval

### DIFF
--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -60,6 +60,11 @@ SIGNAL_MAP_UPDATED = f"{DOMAIN}_map_updated"
 # re-render its options + label in lockstep.
 SIGNAL_SELECTION_CHANGED = f"{DOMAIN}_selection_changed"
 
+# When a zone-map fetch fails (S3 unreachable / transient DNS hiccup) we retry
+# after this many seconds instead of waiting the full `map_refresh_hours`
+# window, so an empty watering-zone select recovers in minutes, not hours.
+MAP_RETRY_BACKOFF_SECONDS = 300
+
 _LOGGER = logging.getLogger(__name__)
 
 _SETTINGS_REFRESH_SECONDS = 30 * 60  # 30 min
@@ -295,7 +300,14 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 if new_ids != prev_ids:
                     # Zone set changed — let platforms (buttons/numbers) rebuild.
                     async_dispatcher_send(self.hass, SIGNAL_MAP_UPDATED, sn, regions)
-            self._last_map_fetch[sn] = now
+                self._last_map_fetch[sn] = now
+            else:
+                # Fetch failed. Don't advance the timer by the full interval, or
+                # a device that has never loaded a map yet would keep an empty
+                # zone select until the next `map_refresh_hours` window (default
+                # 6 h). Schedule the next attempt after a short backoff instead.
+                retry_in = min(MAP_RETRY_BACKOFF_SECONDS, self._map_refresh)
+                self._last_map_fetch[sn] = now - self._map_refresh + retry_in
 
         # History + stats: every `history_refresh_hours`
         if now - self._last_history_fetch.get(sn, 0) > self._history_refresh:


### PR DESCRIPTION
## Problem

The watering-zone select builds its options solely from the cached zone map (`ZoneSelect._refresh_options()` → `coordinator.zones_for()` → `slot["map"]["regions"]`). The coordinator fetches that map every `map_refresh_hours` (default 6 h). On a **failed** fetch it still advanced `_last_map_fetch` by the full interval, so a device that had never successfully loaded a map kept an **empty zone select** — the zone is unselectable and watering can't be started — for up to 6 h before the next attempt.

This surfaced in #35: a user whose network resolves the S3 zone-map host (`prod-europe-app-bucket.s3.eu-central-1.amazonaws.com`) to `0.0.0.0` got `Failed to fetch zone map ...` and an empty zone dropdown that never recovered on its own.

## Fix

On a failed fetch, schedule the next attempt after a short backoff (`MAP_RETRY_BACKOFF_SECONDS = 300`) instead of the full interval — `min(300, self._map_refresh)` so a sub-5-min configured interval never ends up waiting *longer* than normal. The success path is unchanged, and an already-loaded map is left in place on failure, so existing zones survive a transient blip.

One file, coordinator-only.

## Scope note

This fixes the *retry cadence*. It does not, on its own, cure a network that persistently blocks the S3 host (e.g. an ad-blocking DNS returning `0.0.0.0`) — that host still has to be reachable. It does mean that after any transient failure, or once the host is reachable again, the zone select repopulates within minutes rather than hours.

## Testing

- Verified the retry-cadence arithmetic across `map_refresh_hours` values (6 h → 300 s, 1 h → 300 s, 0 h → unchanged every-poll, and a sub-backoff interval which stays capped at the interval, never longer).
- Confirmed the untouched success path on a live 0.3.0 install: both device zone selects populate normally and no zone-map errors are logged.
