### PR TITLE
feat: accept WRZ serial prefix as an IrriSense 2 variant

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -123,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     if not devices:
-        _LOGGER.warning("No Irrisense (WRX/WGX) devices found on this account")
+        _LOGGER.warning("No Irrisense (WRX/WGX/WRZ) devices found on this account")
 
     # Filter out devices the user has disabled in HA's device registry.
     # Devices not yet in the registry are let through so first-time setup

--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -484,7 +484,7 @@ class IrrisenseApi:
                 sn = device.get("sn")
                 if not sn:
                     continue
-                # Filter: only Irrisense serials (WRX / WGX prefix). Leave other
+                # Filter: only Irrisense serials (WRX / WGX / WRZ prefix). Leave other
                 # aiper devices to the sibling ha-aiper integration.
                 if not sn.upper().startswith(IRRISENSE_SERIAL_PREFIXES):
                     continue

--- a/custom_components/aiper_irrisense/config_flow.py
+++ b/custom_components/aiper_irrisense/config_flow.py
@@ -63,7 +63,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         await hass.async_add_executor_job(api.disconnect)
 
     if not devices:
-        # Account authenticated but no Irrisense (WRX / WGX) devices were returned
+        # Account authenticated but no Irrisense (WRX / WGX / WRZ) devices were returned
         # — probably wrong account for Irrisense, or the user only owns pool cleaners.
         raise NoIrrisenseDevices
 
@@ -187,4 +187,4 @@ class InvalidAuth(HomeAssistantError):
 
 
 class NoIrrisenseDevices(HomeAssistantError):
-    """Account has no Irrisense (WRX / WGX) devices."""
+    """Account has no Irrisense (WRX / WGX / WRZ) devices."""

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -20,8 +20,9 @@ API_ENDPOINTS: Final = {
 }
 
 # Irrisense serial prefixes. `WRX` is the original/online-store SKU; `WGX` is
-# the big-box-retail variant (e.g. Costco). Both speak the same wire protocol.
-IRRISENSE_SERIAL_PREFIXES: Final = ("WRX", "WGX")
+# the big-box-retail variant (e.g. Costco); `WRZ` is a further retail variant.
+# All speak the same wire protocol.
+IRRISENSE_SERIAL_PREFIXES: Final = ("WRX", "WGX", "WRZ")
 
 # Model string as written into the S3 zone-map path.
 IRRISENSE_MODEL: Final = "IrriSense_2"

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WRZ serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX) devices were found on this account.",
+      "no_devices": "No Irrisense (WRX / WGX / WRZ) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Aiper Irrisense 2",
-        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX serial prefix) will be added.",
+        "description": "Sign in with your Aiper account. Only Irrisense devices (WRX / WGX / WRZ serial prefix) will be added.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -21,7 +21,7 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Failed to connect to the Aiper cloud.",
-      "no_devices": "No Irrisense (WRX / WGX) devices were found on this account.",
+      "no_devices": "No Irrisense (WRX / WGX / WRZ) devices were found on this account.",
       "unknown": "Unexpected error."
     },
     "abort": {


### PR DESCRIPTION
Units whose serial starts with the WRZ prefix are IrriSense 2 variants but weren't recognized during setup. This accepts WRZ as a valid IrriSense 2 variant. Touches const.py, config_flow.py, api.py, __init__.py, strings/translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)