### PR TITLE
feat: opt-in experimental pesticide-usage and skip-history sensors

### DIFF
--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -563,8 +563,8 @@ class IrrisenseApi:
                 sn = device.get("sn")
                 if not sn:
                     continue
-                # Filter: only Irrisense serials (WRX / WGX prefix). Leave other
-                # aiper devices to the sibling ha-aiper integration.
+                # Filter: only Irrisense serials (WR / WG / WC / WL family).
+                # Leave other aiper devices to the sibling ha-aiper integration.
                 if not sn.upper().startswith(IRRISENSE_SERIAL_PREFIXES):
                     continue
                 self._devices[sn] = device

--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -174,6 +174,37 @@ def _find_map_url(obj: Any) -> str | None:
     return None
 
 
+def _find_map_id(obj: Any) -> int | None:
+    """Recursively scan a getMapList response for the map-document id.
+
+    Mirrors :func:`_find_map_url`: prefer the explicitly-named keys, then
+    fall back to a bare ``id`` on a map-looking object. Returns the first
+    integer id found, or None.
+    """
+    if isinstance(obj, dict):
+        for key in ("mapId", "map_id"):
+            val = obj.get(key)
+            if isinstance(val, int):
+                return val
+        # A map object that also carries the S3 url is the map document;
+        # its bare `id` is the map id.
+        if "id" in obj and _find_map_url(obj) is not None:
+            val = obj.get("id")
+            if isinstance(val, int):
+                return val
+        for val in obj.values():
+            found = _find_map_id(val)
+            if found is not None:
+                return found
+        return None
+    if isinstance(obj, list):
+        for item in obj:
+            found = _find_map_id(item)
+            if found is not None:
+                return found
+    return None
+
+
 class IrrisenseApi:
     """REST + MQTT client for the Aiper Irrisense 2."""
 
@@ -661,11 +692,27 @@ class IrrisenseApi:
     def get_drainage_reminder(self, sn: str) -> dict | None:
         return self._wr("/wr/getDrainageReminderPopup", {"sn": sn})
 
-    def get_map_pesticide_usage(self, sn: str) -> dict | None:
-        return self._wr("/wr/getMapPesticideUsage", {"sn": sn})
+    def get_map_id(self, sn: str) -> int | None:
+        """Resolve the map-document id from getMapList (needed by
+        getMapPesticideUsage). Separate from the region/zone ids used for
+        watering — this is the id of the whole map document."""
+        return _find_map_id(self.get_map_list(sn))
 
-    def get_skip_history(self, sn: str) -> dict | None:
-        return self._wr("/wr/getWateringTaskSkipRecordHistoryDataV2", {"sn": sn})
+    def get_map_pesticide_usage(self, sn: str, map_id: int) -> dict | None:
+        return self._wr("/wr/getMapPesticideUsage", {"sn": sn, "mapId": map_id})
+
+    def get_skip_history(self, sn: str, days: int = 30) -> dict | None:
+        # Backend wants a time window in whole seconds (start/end); an empty
+        # body returns code=6002. Default to the last `days` days.
+        now_s = int(time.time())
+        return self._wr(
+            "/wr/getWateringTaskSkipRecordHistoryDataV2",
+            {
+                "sn": sn,
+                "startTimestampSecond": now_s - days * 24 * 3600,
+                "endTimestampSecond": now_s,
+            },
+        )
 
     @staticmethod
     def _parse_regions(zmap: dict | None) -> list[dict[str, Any]]:

--- a/custom_components/aiper_irrisense/config_flow.py
+++ b/custom_components/aiper_irrisense/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .api import IrrisenseApi
 from .const import (
+    CONF_ENABLE_EXPERIMENTAL_SENSORS,
     CONF_ENABLE_MQTT,
     CONF_HISTORY_REFRESH_HOURS,
     CONF_MAP_REFRESH_HOURS,
@@ -177,6 +178,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_REMINDER_REFRESH_HOURS,
                     default=current.get(CONF_REMINDER_REFRESH_HOURS, DEFAULT_REMINDER_REFRESH_HOURS),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1, max=168)),
+                vol.Optional(
+                    CONF_ENABLE_EXPERIMENTAL_SENSORS,
+                    default=current.get(CONF_ENABLE_EXPERIMENTAL_SENSORS, False),
+                ): bool,
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -42,6 +42,7 @@ CONF_POLL_INTERVAL: Final = "poll_interval"
 CONF_MAP_REFRESH_HOURS: Final = "map_refresh_hours"
 CONF_HISTORY_REFRESH_HOURS: Final = "history_refresh_hours"
 CONF_REMINDER_REFRESH_HOURS: Final = "reminder_refresh_hours"
+CONF_ENABLE_EXPERIMENTAL_SENSORS: Final = "enable_experimental_sensors"
 
 DEFAULT_SCAN_INTERVAL: Final = 120  # seconds
 DEFAULT_FAST_SCAN_INTERVAL: Final = 5  # seconds during an active watering event

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import IrrisenseApi
 from .const import (
+    CONF_ENABLE_EXPERIMENTAL_SENSORS,
     CONF_HISTORY_REFRESH_HOURS,
     CONF_MAP_REFRESH_HOURS,
     CONF_POLL_INTERVAL,
@@ -164,6 +165,9 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._last_history_fetch: dict[str, float] = {}
         self._last_reminder_fetch: dict[str, float] = {}
         self._last_settings_fetch: dict[str, float] = {}
+        self._last_experimental_fetch: dict[str, float] = {}
+        # Map-document id per SN, resolved once (stable) for pesticide usage.
+        self._map_id: dict[str, int] = {}
 
         # User's current Dashboard selection (controls card).
         # Populated by the ZoneSelect / DoseSelect entities; read by the
@@ -213,6 +217,10 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._map_refresh = int(opts.get(CONF_MAP_REFRESH_HOURS, DEFAULT_MAP_REFRESH_HOURS)) * 3600
         self._history_refresh = int(opts.get(CONF_HISTORY_REFRESH_HOURS, DEFAULT_HISTORY_REFRESH_HOURS)) * 3600
         self._reminder_refresh = int(opts.get(CONF_REMINDER_REFRESH_HOURS, DEFAULT_REMINDER_REFRESH_HOURS)) * 3600
+        # Opt-in experimental sensors (pesticide usage, skip history). Off by
+        # default; the entry reloads on options change, so toggling this
+        # creates/removes the entities on the next reload.
+        self._experimental = bool(opts.get(CONF_ENABLE_EXPERIMENTAL_SENSORS, False))
 
     # ------------------------------------------------------------------ #
     # Public helpers
@@ -327,6 +335,25 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 self.api.get_reminder_setting, sn
             )
             self._last_reminder_fetch[sn] = now
+
+        # Experimental (opt-in): pesticide usage + skip history, on the
+        # history cadence. Both come back empty on devices with no cartridge
+        # bound / no skipped runs, and each call returns None on error, so
+        # this never breaks the main poll.
+        if self._experimental and now - self._last_experimental_fetch.get(sn, 0) > self._history_refresh:
+            slot["skip"] = await self.hass.async_add_executor_job(
+                self.api.get_skip_history, sn
+            )
+            map_id = self._map_id.get(sn)
+            if map_id is None:
+                map_id = await self.hass.async_add_executor_job(self.api.get_map_id, sn)
+                if map_id is not None:
+                    self._map_id[sn] = map_id
+            if map_id is not None:
+                slot["pesticide"] = await self.hass.async_add_executor_job(
+                    self.api.get_map_pesticide_usage, sn, map_id
+                )
+            self._last_experimental_fetch[sn] = now
 
     # ------------------------------------------------------------------ #
     # MQTT integration

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import EntityCategory, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import CONF_ENABLE_EXPERIMENTAL_SENSORS, DOMAIN
 from .coordinator import IrrisenseCoordinator
 from .entity import IrrisenseEntity
 
@@ -48,6 +48,13 @@ async def async_setup_entry(
                 LastWateringZoneSensor(coordinator, sn),
             ]
         )
+        if entry.options.get(CONF_ENABLE_EXPERIMENTAL_SENSORS, False):
+            entities.extend(
+                [
+                    SkipHistorySensor(coordinator, sn),
+                    PesticideUsageSensor(coordinator, sn),
+                ]
+            )
     async_add_entities(entities)
 
 
@@ -482,3 +489,112 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
                 "depth_mm": last.get("depth") or last.get("waterYield"),
             }
         return None
+
+
+# --------------------------------------------------------------------------- #
+# Experimental (opt-in) — pesticide usage + skip history. Both come back empty
+# on devices with no cartridge bound / no skipped runs, so the sensors report
+# None until real data appears. Payload shapes are best-effort (dug
+# defensively) since they can't be exercised on a non-sprayer test device.
+# --------------------------------------------------------------------------- #
+
+# Known skipType reasons; unmapped ints fall back to "type_<n>".
+SKIP_TYPE_LABELS: dict[int, str] = {
+    3: "weather_wind",
+    4: "weather_rain",
+    5: "on_rain",
+    9: "manual_task",
+}
+
+
+def _records(payload: Any) -> list[dict[str, Any]]:
+    """Records list from a `_wr` result. `_wr` already unwraps the response
+    `data`, so this is either a bare list or a dict wrapping one under
+    list/records/data."""
+    if isinstance(payload, dict):
+        payload = payload.get("list") or payload.get("records") or payload.get("data")
+    if isinstance(payload, list):
+        return [r for r in payload if isinstance(r, dict)]
+    return []
+
+
+class SkipHistorySensor(IrrisenseEntity, SensorEntity):
+    """Reason the most recent scheduled run was skipped (rain, wind, etc.)."""
+
+    _attr_icon = "mdi:calendar-remove"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "last_skip"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_skip")
+        self._attr_name = "Last skip reason"
+
+    def _latest(self) -> dict[str, Any] | None:
+        records = _records(self._slot.get("skip"))
+        if not records:
+            return None
+        return max(records, key=lambda r: r.get("skipTaskUtcTimestampSecond") or 0)
+
+    @property
+    def native_value(self) -> str | None:
+        latest = self._latest()
+        if latest is None:
+            return None
+        stype = latest.get("skipType")
+        if not isinstance(stype, int):
+            return None
+        return SKIP_TYPE_LABELS.get(stype, f"type_{stype}")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        records = _records(self._slot.get("skip"))
+        if not records:
+            return None
+        latest = max(records, key=lambda r: r.get("skipTaskUtcTimestampSecond") or 0)
+        ts = latest.get("skipTaskUtcTimestampSecond")
+        skipped_at = None
+        if isinstance(ts, int):
+            skipped_at = datetime.fromtimestamp(ts, timezone.utc).isoformat()
+        return {
+            "skipped_at": skipped_at,
+            "skip_type": latest.get("skipType"),
+            "task_id": latest.get("taskId"),
+            "plan_id": latest.get("planId"),
+            "count": len(records),
+        }
+
+
+class PesticideUsageSensor(IrrisenseEntity, SensorEntity):
+    """Number of zones with logged pesticide usage; the per-zone payload is
+    carried in the attributes (IrriSense 2 sprayer module)."""
+
+    _attr_icon = "mdi:spray"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "pesticide_usage"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "pesticide_usage")
+        self._attr_name = "Pesticide usage zones"
+
+    def _usage_list(self) -> list[dict[str, Any]] | None:
+        # `_wr` already unwraps the response `data`, so slot["pesticide"] is
+        # the MapPesticideUsage object itself (mapId + mapPesticideUsageList).
+        payload = self._slot.get("pesticide")
+        if not isinstance(payload, dict):
+            return None
+        regions = payload.get("mapPesticideUsageList")
+        if isinstance(regions, list):
+            return [r for r in regions if isinstance(r, dict)]
+        return None
+
+    @property
+    def native_value(self) -> int | None:
+        regions = self._usage_list()
+        return None if regions is None else len(regions)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        regions = self._usage_list()
+        if regions is None:
+            return None
+        return {"regions": regions[:20]}

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -38,13 +38,16 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "enable_experimental_sensors": "Enable experimental sensors (pesticide usage, skip history)"
         }
       }
     }
   },
   "entity": {
     "sensor": {
+      "pesticide_usage": {"name": "Pesticide usage zones"},
+      "last_skip": {"name": "Last skip reason"},
       "active_zone": {"name": "Active zone"},
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -38,7 +38,8 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "enable_experimental_sensors": "Enable experimental sensors (pesticide usage, skip history)"
         }
       }
     }
@@ -54,7 +55,9 @@
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},
       "water_month": {"name": "Water usage this month"},
-      "last_zone": {"name": "Last watered zone"}
+      "last_zone": {"name": "Last watered zone"},
+      "last_skip": {"name": "Last skip reason"},
+      "pesticide_usage": {"name": "Pesticide usage zones"}
     },
     "binary_sensor": {
       "online": {"name": "Online"},


### PR DESCRIPTION
## Summary

Adds two read-only sensors aimed at IrriSense 2 sprayer owners, behind a new **"Enable experimental sensors"** options toggle (off by default). Addresses #30.

- **Pesticide usage zones** — number of zones with logged pesticide usage; the per-zone payload is carried in the sensor attributes (`getMapPesticideUsage`).
- **Last skip reason** — why the most recent scheduled run was skipped (rain / wind / manual / …), from `getWateringTaskSkipRecordHistoryDataV2`. Attributes carry the timestamp, raw `skipType`, task/plan id and the count over the window.

## Why a toggle

Both features only produce data on a device that has a pesticide cartridge bound / has actually skipped a run. On a normal irrigation-only setup they are always empty, so hiding them behind an opt-in keeps the entity list clean for everyone else. The config entry already reloads on options change, so flipping the toggle creates/removes the entities on the next reload.

## Changes

- `api.py`: the existing `get_map_pesticide_usage` / `get_skip_history` helpers sent incomplete bodies (missing `mapId` / time window) that the backend rejects with code `6002`. Both now send the required fields. New `_find_map_id` resolves the map-document id from `getMapList`, and `get_map_id` wraps it.
- `coordinator.py`: fetches both on the history cadence, **only when the toggle is on**. Each call returns `None` on error, so the experimental path never breaks the main poll.
- `sensor.py`: the two sensors, created only when the toggle is enabled; both report `None`/`0` until real data appears.
- `config_flow.py` / `const.py` / `translations`: the options toggle.

## Testing

Request and response container shapes verified against a live account (all `HTTP 200`, not `6002`):

- `getMapList` returns the map-document id under `data[].id`; `_find_map_id` extracts it correctly.
- `getMapPesticideUsage {sn, mapId}` → `data: {mapId, mapPesticideUsageList: [...]}` — exactly what the pesticide sensor reads.
- `getWateringTaskSkipRecordHistoryDataV2 {sn, startTimestampSecond, endTimestampSecond}` → `data: [...]` (a bare list) — what the skip sensor reads.

The lists come back empty on a device with no cartridge / no skipped runs, so the inner record fields (the `skipType` enum values, the per-region usage fields) can't be exercised here — hence the experimental gate. The pesticide sensor deliberately doesn't depend on the inner field names (it carries the raw list and counts it), so it stays robust whatever they turn out to be.
