### PR TITLE
Re-claim the session on HTTP 402 + a session-conflict sensor

### DIFF
--- a/custom_components/aiper_irrisense/api.py
+++ b/custom_components/aiper_irrisense/api.py
@@ -189,6 +189,15 @@ class IrrisenseApi:
         self._user_id: str | None = None
         self._token_expires: int = 0
 
+        # Session-conflict (HTTP 402 "account used on another device") state.
+        # Our REST token gets evicted whenever a second client (the Aiper app,
+        # another integration) logs into the same account. Re-claim at most
+        # once per cooldown to avoid a login ping-pong, and expose the flag so
+        # a diagnostic binary_sensor can surface the contention.
+        self._session_conflict: bool = False
+        self._last_conflict_relogin: float = 0.0
+        self._conflict_relogin_cooldown: int = 300
+
         # AWS IoT state
         self._identity_id: str | None = None
         self._identity_pool_id: str | None = None
@@ -351,7 +360,9 @@ class IrrisenseApi:
                 f"Failed to parse decrypted response from {path}: {decrypted[:200]}"
             ) from err
 
-        if retry_login and str(payload.get("code")) in ("401", "403"):
+        code = str(payload.get("code"))
+
+        if retry_login and code in ("401", "403"):
             _LOGGER.info("Token expired; refreshing")
             if self.refresh_token() or self.login():
                 return self._call_encrypted(
@@ -359,6 +370,38 @@ class IrrisenseApi:
                     base_url=base_url, token=self._token,
                     timeout=timeout, retry_login=False,
                 )
+        elif retry_login and code == "402":
+            # 402 = "account used on another device": our token was evicted by
+            # a concurrent login. A re-login re-claims the session but evicts
+            # *them*, so two clients can ping-pong logins forever. Re-claim at
+            # most once per cooldown; if the conflict persists we stop fighting,
+            # flag it, and let REST data go stale until the other client
+            # releases (MQTT rides a separate session and stays up).
+            now = time.time()
+            if now - self._last_conflict_relogin >= self._conflict_relogin_cooldown:
+                self._last_conflict_relogin = now
+                _LOGGER.warning(
+                    "Aiper session evicted (402, account in use elsewhere); "
+                    "re-claiming the session once"
+                )
+                if self.login():
+                    self._session_conflict = False
+                    return self._call_encrypted(
+                        method, path, body,
+                        base_url=base_url, token=self._token,
+                        timeout=timeout, retry_login=False,
+                    )
+            else:
+                _LOGGER.warning(
+                    "Aiper session conflict persists (402); backing off ~%ds to "
+                    "avoid a login ping-pong with the other client",
+                    self._conflict_relogin_cooldown,
+                )
+            self._session_conflict = True
+            return payload
+
+        if self._session_conflict and self._is_success(payload):
+            self._session_conflict = False
 
         return payload
 
@@ -405,6 +448,12 @@ class IrrisenseApi:
         except Exception as err:
             _LOGGER.debug("Token refresh failed: %s", err)
         return False
+
+    @property
+    def session_conflict(self) -> bool:
+        """True while another client is contending the account (a 402 that we
+        backed off from rather than re-claim). Cleared on the next success."""
+        return self._session_conflict
 
     def _get_openid_token(self) -> None:
         try:

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -29,6 +29,7 @@ async def async_setup_entry(
                 OnlineBinarySensor(coordinator, sn),
                 WateringBinarySensor(coordinator, sn),
                 RainSensingBinarySensor(coordinator, sn),
+                SessionConflictBinarySensor(coordinator, sn),
             ]
         )
     async_add_entities(entities)
@@ -53,6 +54,31 @@ class OnlineBinarySensor(IrrisenseEntity, BinarySensorEntity):
         if isinstance(val, (int, str)):
             return str(val).lower() in ("1", "true", "online")
         return False
+
+
+class SessionConflictBinarySensor(IrrisenseEntity, BinarySensorEntity):
+    """On while another client is contending the Aiper account.
+
+    The cloud allows a single session per account; a login elsewhere (the
+    Aiper app, another integration) evicts this integration's REST token
+    (HTTP 402). This flags that state so it can drive a notification — MQTT
+    rides a separate session and keeps working, only REST-backed data goes
+    stale until the other client releases. Account-scoped, so every device
+    reports the same value.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:account-alert"
+    _attr_translation_key = "session_conflict"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "session_conflict")
+        self._attr_name = "Session conflict"
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self.coordinator.api.session_conflict)
 
 
 class WateringBinarySensor(IrrisenseEntity, BinarySensorEntity):

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -58,7 +58,8 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
-      "watering": {"name": "Watering"}
+      "watering": {"name": "Watering"},
+      "session_conflict": {"name": "Session conflict"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -58,7 +58,8 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
-      "watering": {"name": "Watering"}
+      "watering": {"name": "Watering"},
+      "session_conflict": {"name": "Session conflict"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},


### PR DESCRIPTION
The Aiper cloud allows a single session per account. When a second client logs in (the phone app, another integration), our REST token is evicted and the backend returns HTTP `402 "account used on another device"`.

`_call_encrypted` only re-logged in on `401`/`403`, so a `402` was never recovered from — every REST call looped on it while the AWS-IoT MQTT session (separate) stayed connected. That **masked** the outage: entities looked online, but the REST-backed slices (equipment info, weather, settings, history) silently went stale.

## Changes
- **`402` now re-claims the session**, but **at most once per cooldown (300 s)**. A naive "re-login on every 402" ping-pongs with the other client — each login evicts the other. If the conflict persists we back off and flag it instead of fighting.
- **New diagnostic `binary_sensor.*_session_conflict`** (device_class `problem`): surfaces the contention so it can drive a "close the Aiper app" notification. Account-scoped — every device reports the same value.

## Notes
- `401`/`403` handling is unchanged.
- MQTT rides a separate session and is unaffected; this only restores the REST path.
- Independent of #38 (that raises setup-time login timeouts) — no file overlap, complementary.
