### PR TITLE
Add rain + wind skip-threshold number entities

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -30,6 +30,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
     Platform.BUTTON,
+    Platform.NUMBER,
 ]
 # Dose lives on the Watering Dose select (label-valued: "3 mm" / "5 min" / ...)
 # and backend mapping happens in button.StartWateringButton.

--- a/custom_components/aiper_irrisense/number.py
+++ b/custom_components/aiper_irrisense/number.py
@@ -5,14 +5,27 @@ adjustable numbers: the rain amount and the wind speed above which the device
 defers a scheduled run. Both write back through ``updateWateringSetting`` (full
 setting object merged by the coordinator).
 
-The device reports these as bare floats; the app's own unit for each is not
-surfaced on the API, so the entities are left unitless and mirror the value
-shown in the app rather than asserting an unverified unit.
+Wire units (the raw float the device stores) are fixed regardless of the user's
+locale; the Aiper app converts them for display:
+
+* ``rainAmount``  -> **inches** (app gauge 0.1-1.0 in), shown as mm for metric
+  users. Cross-checked against a real device: raw 0.5 renders as ~13 mm.
+* ``windSpeed``   -> **metres/second** (app slider 2.2-20.1 m/s), shown as km/h
+  or mph. Cross-checked: raw 8.2 renders as ~30 km/h (8.2 * 3.6 = 29.5).
+
+So each entity declares its native unit and a matching device class; Home
+Assistant then converts to the viewer's unit system automatically, and
+``async_set_native_value`` always receives (and writes) the native wire value.
 """
 from __future__ import annotations
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfPrecipitationDepth, UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -65,27 +78,29 @@ class RainThresholdNumber(_SettingNumber):
     """Rain amount above which a scheduled run is skipped (``rainAmount``)."""
 
     _setting_key = "rainAmount"
-    _attr_native_min_value = 0.0
-    _attr_native_max_value = 25.0
+    _attr_device_class = NumberDeviceClass.PRECIPITATION
+    _attr_native_unit_of_measurement = UnitOfPrecipitationDepth.INCHES
+    _attr_native_min_value = 0.1
+    _attr_native_max_value = 1.0
     _attr_native_step = 0.1
     _attr_icon = "mdi:weather-rainy"
     _attr_translation_key = "rain_threshold"
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "rain_threshold")
-        self._attr_name = "Rain threshold"
 
 
 class WindThresholdNumber(_SettingNumber):
     """Wind speed above which a scheduled run is skipped (``windSpeed``)."""
 
     _setting_key = "windSpeed"
-    _attr_native_min_value = 0.0
-    _attr_native_max_value = 50.0
-    _attr_native_step = 0.5
+    _attr_device_class = NumberDeviceClass.WIND_SPEED
+    _attr_native_unit_of_measurement = UnitOfSpeed.METERS_PER_SECOND
+    _attr_native_min_value = 2.2
+    _attr_native_max_value = 20.1
+    _attr_native_step = 0.1
     _attr_icon = "mdi:weather-windy"
     _attr_translation_key = "wind_threshold"
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "wind_threshold")
-        self._attr_name = "Wind threshold"

--- a/custom_components/aiper_irrisense/number.py
+++ b/custom_components/aiper_irrisense/number.py
@@ -5,18 +5,32 @@ adjustable numbers: the rain amount and the wind speed above which the device
 defers a scheduled run. Both write back through ``updateWateringSetting`` (full
 setting object merged by the coordinator).
 
-Wire units (the raw float the device stores) are fixed regardless of the user's
-locale; the Aiper app converts them for display:
+The device stores these as bare floats in fixed units, regardless of the user's
+locale - the Aiper app is what converts them for display:
 
-* ``rainAmount``  -> **inches** (app gauge 0.1-1.0 in), shown as mm for metric
-  users. Cross-checked against a real device: raw 0.5 renders as ~13 mm.
-* ``windSpeed``   -> **metres/second** (app slider 2.2-20.1 m/s), shown as km/h
-  or mph. Cross-checked: raw 8.2 renders as ~30 km/h (8.2 * 3.6 = 29.5).
+* ``rainAmount``  -> **inches** (app gauge 0.1-1.0 in, 0.1 steps). Cross-checked
+  against a real device: raw 0.5 renders as ~13 mm in a metric app.
+* ``windSpeed``   -> **metres/second** (app slider 2.2-20.1 m/s, 0.1 steps).
+  Cross-checked: raw 8.2 renders as ~30 km/h (8.2 * 3.6 = 29.5).
 
-So each entity declares its native unit and a matching device class; Home
-Assistant then converts to the viewer's unit system automatically, and
-``async_set_native_value`` always receives (and writes) the native wire value.
+Unlike sensors, a ``number`` does not follow the unit system on its own: core
+only auto-converts numbers for ``NumberDeviceClass.TEMPERATURE``, and the number
+platform has no ``suggested_unit_of_measurement``. Declaring the wire unit as
+the entity unit would therefore show inches and m/s to every user, metric ones
+included.
+
+So the entities publish millimetres and km/h - the units the app shows the
+majority of users - and convert to the wire unit at the write boundary using the
+core converters. The wire unit stays an implementation detail of the cloud
+protocol. Users who prefer inches, mph or knots pick that unit per entity in the
+entity settings; both device classes sit in the number platform's converter
+table, so core then converts display and input for them.
+
+Input is snapped onto the device's own grid before it is sent (see
+``number_grid``), so a metric user typing 13 mm gets the 0.5 in the device
+supports rather than an off-grid 0.512 in.
 """
+
 from __future__ import annotations
 
 from homeassistant.components.number import (
@@ -28,10 +42,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPrecipitationDepth, UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.unit_conversion import (
+    BaseUnitConverter,
+    DistanceConverter,
+    SpeedConverter,
+)
 
 from .const import DOMAIN
 from .coordinator import IrrisenseCoordinator
 from .entity import IrrisenseEntity
+from .number_grid import snap_to_grid
 
 
 async def async_setup_entry(
@@ -53,10 +73,21 @@ async def async_setup_entry(
 
 
 class _SettingNumber(IrrisenseEntity, NumberEntity):
-    """Base for a single float key in the ``setting`` slot."""
+    """Base for a single float key in the ``setting`` slot.
+
+    Subclasses declare the entity unit through ``_attr_native_unit_of_measurement``
+    and the device's own unit and grid through ``_wire_*``; conversion between the
+    two runs through ``_converter``.
+    """
 
     _setting_key: str = ""
     _attr_mode = NumberMode.BOX
+
+    _converter: type[BaseUnitConverter]
+    _wire_unit: str = ""
+    _wire_min: float = 0.0
+    _wire_max: float = 0.0
+    _wire_step: float = 0.1
 
     @property
     def native_value(self) -> float | None:
@@ -65,13 +96,24 @@ class _SettingNumber(IrrisenseEntity, NumberEntity):
             return None
         val = setting.get(self._setting_key)
         if isinstance(val, (int, float)) and not isinstance(val, bool):
-            return float(val)
+            return round(self._from_wire(float(val)), 2)
         return None
 
     async def async_set_native_value(self, value: float) -> None:
         await self.coordinator.async_set_watering_setting(
-            self._sn, {self._setting_key: value}
+            self._sn, {self._setting_key: self._to_wire(value)}
         )
+
+    def _from_wire(self, value: float) -> float:
+        return self._converter.converter_factory(
+            self._wire_unit, self._attr_native_unit_of_measurement
+        )(value)
+
+    def _to_wire(self, value: float) -> float:
+        wire = self._converter.converter_factory(
+            self._attr_native_unit_of_measurement, self._wire_unit
+        )(value)
+        return snap_to_grid(wire, self._wire_step, self._wire_min, self._wire_max)
 
 
 class RainThresholdNumber(_SettingNumber):
@@ -79,12 +121,19 @@ class RainThresholdNumber(_SettingNumber):
 
     _setting_key = "rainAmount"
     _attr_device_class = NumberDeviceClass.PRECIPITATION
-    _attr_native_unit_of_measurement = UnitOfPrecipitationDepth.INCHES
-    _attr_native_min_value = 0.1
-    _attr_native_max_value = 1.0
+    _attr_native_unit_of_measurement = UnitOfPrecipitationDepth.MILLIMETERS
+    # 0.1-1.0 in on the device, i.e. 2.54-25.4 mm.
+    _attr_native_min_value = 2.54
+    _attr_native_max_value = 25.4
     _attr_native_step = 0.1
     _attr_icon = "mdi:weather-rainy"
     _attr_translation_key = "rain_threshold"
+
+    _converter = DistanceConverter
+    _wire_unit = UnitOfPrecipitationDepth.INCHES
+    _wire_min = 0.1
+    _wire_max = 1.0
+    _wire_step = 0.1
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "rain_threshold")
@@ -95,12 +144,19 @@ class WindThresholdNumber(_SettingNumber):
 
     _setting_key = "windSpeed"
     _attr_device_class = NumberDeviceClass.WIND_SPEED
-    _attr_native_unit_of_measurement = UnitOfSpeed.METERS_PER_SECOND
-    _attr_native_min_value = 2.2
-    _attr_native_max_value = 20.1
+    _attr_native_unit_of_measurement = UnitOfSpeed.KILOMETERS_PER_HOUR
+    # 2.2-20.1 m/s on the device, i.e. 7.92-72.36 km/h.
+    _attr_native_min_value = 7.92
+    _attr_native_max_value = 72.36
     _attr_native_step = 0.1
     _attr_icon = "mdi:weather-windy"
     _attr_translation_key = "wind_threshold"
+
+    _converter = SpeedConverter
+    _wire_unit = UnitOfSpeed.METERS_PER_SECOND
+    _wire_min = 2.2
+    _wire_max = 20.1
+    _wire_step = 0.1
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "wind_threshold")

--- a/custom_components/aiper_irrisense/number.py
+++ b/custom_components/aiper_irrisense/number.py
@@ -1,0 +1,91 @@
+"""Number platform for the Aiper Irrisense 2.
+
+Exposes the two weather-skip thresholds from the watering-setting slot as
+adjustable numbers: the rain amount and the wind speed above which the device
+defers a scheduled run. Both write back through ``updateWateringSetting`` (full
+setting object merged by the coordinator).
+
+The device reports these as bare floats; the app's own unit for each is not
+surfaced on the API, so the entities are left unitless and mirror the value
+shown in the app rather than asserting an unverified unit.
+"""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import IrrisenseCoordinator
+from .entity import IrrisenseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: IrrisenseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[NumberEntity] = []
+    for dev in coordinator.devices:
+        sn = dev.get("sn")
+        if not sn:
+            continue
+        entities.extend(
+            [
+                RainThresholdNumber(coordinator, sn),
+                WindThresholdNumber(coordinator, sn),
+            ]
+        )
+    async_add_entities(entities)
+
+
+class _SettingNumber(IrrisenseEntity, NumberEntity):
+    """Base for a single float key in the ``setting`` slot."""
+
+    _setting_key: str = ""
+    _attr_mode = NumberMode.BOX
+
+    @property
+    def native_value(self) -> float | None:
+        setting = self._slot.get("setting")
+        if not isinstance(setting, dict):
+            return None
+        val = setting.get(self._setting_key)
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return float(val)
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.async_set_watering_setting(
+            self._sn, {self._setting_key: value}
+        )
+
+
+class RainThresholdNumber(_SettingNumber):
+    """Rain amount above which a scheduled run is skipped (``rainAmount``)."""
+
+    _setting_key = "rainAmount"
+    _attr_native_min_value = 0.0
+    _attr_native_max_value = 25.0
+    _attr_native_step = 0.1
+    _attr_icon = "mdi:weather-rainy"
+    _attr_translation_key = "rain_threshold"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "rain_threshold")
+        self._attr_name = "Rain threshold"
+
+
+class WindThresholdNumber(_SettingNumber):
+    """Wind speed above which a scheduled run is skipped (``windSpeed``)."""
+
+    _setting_key = "windSpeed"
+    _attr_native_min_value = 0.0
+    _attr_native_max_value = 50.0
+    _attr_native_step = 0.5
+    _attr_icon = "mdi:weather-windy"
+    _attr_translation_key = "wind_threshold"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "wind_threshold")
+        self._attr_name = "Wind threshold"

--- a/custom_components/aiper_irrisense/number_grid.py
+++ b/custom_components/aiper_irrisense/number_grid.py
@@ -1,0 +1,24 @@
+"""Grid helpers for the threshold numbers.
+
+The device stores the weather-skip thresholds on a coarse grid (0.1 in of rain,
+0.1 m/s of wind) - the same grid the Aiper app offers. A value entered in a
+different unit rarely lands on that grid, so it is snapped before it goes to
+the cloud, exactly like the app does.
+
+Kept free of Home Assistant imports so it can be unit-tested on its own.
+"""
+
+from __future__ import annotations
+
+
+def snap_to_grid(
+    value: float, step: float, minimum: float, maximum: float
+) -> float:
+    """Snap ``value`` onto the device grid and clamp it to the device range.
+
+    ``step``/``minimum``/``maximum`` are expressed in the device's own unit, so
+    the caller converts first and snaps second. The result is rounded to three
+    decimals to keep float noise (0.30000000000000004) off the wire.
+    """
+    snapped = round(value / step) * step
+    return round(min(max(snapped, minimum), maximum), 3)

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -70,6 +70,10 @@
     "button": {
       "start_watering": {"name": "Start watering"},
       "stop_watering": {"name": "Stop watering"}
+    },
+    "number": {
+      "rain_threshold": {"name": "Rain threshold"},
+      "wind_threshold": {"name": "Wind threshold"}
     }
   },
   "services": {

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -70,6 +70,10 @@
     "button": {
       "start_watering": {"name": "Start watering"},
       "stop_watering": {"name": "Stop watering"}
+    },
+    "number": {
+      "rain_threshold": {"name": "Rain threshold"},
+      "wind_threshold": {"name": "Wind threshold"}
     }
   },
   "services": {

--- a/tests/test_number_grid.py
+++ b/tests/test_number_grid.py
@@ -1,0 +1,54 @@
+"""Unit tests for the pure threshold-number grid helper.
+
+`number_grid.py` is stdlib-only (no homeassistant import), so we file-load it
+directly to avoid executing the package __init__.py (which imports HA).
+"""
+import importlib.util
+import pathlib
+
+_GRID_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "custom_components" / "aiper_irrisense" / "number_grid.py"
+)
+_spec = importlib.util.spec_from_file_location("number_grid", _GRID_PATH)
+grid = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(grid)
+
+# Rain: the device stores inches on a 0.1 grid, 0.1-1.0.
+RAIN = dict(step=0.1, minimum=0.1, maximum=1.0)
+# Wind: metres per second on a 0.1 grid, 2.2-20.1.
+WIND = dict(step=0.1, minimum=2.2, maximum=20.1)
+
+
+def test_on_grid_value_survives():
+    assert grid.snap_to_grid(0.5, **RAIN) == 0.5
+    assert grid.snap_to_grid(8.2, **WIND) == 8.2
+
+
+def test_off_grid_value_snaps_to_nearest_step():
+    # 13 mm converts to 0.5118 in — the device only takes 0.5.
+    assert grid.snap_to_grid(0.5118110236220472, **RAIN) == 0.5
+    # 30 km/h converts to 8.333 m/s — nearest device step is 8.3.
+    assert grid.snap_to_grid(8.333333333333334, **WIND) == 8.3
+
+
+def test_clamped_to_device_range():
+    assert grid.snap_to_grid(0.02, **RAIN) == 0.1
+    assert grid.snap_to_grid(3.0, **RAIN) == 1.0
+    assert grid.snap_to_grid(0.0, **WIND) == 2.2
+    assert grid.snap_to_grid(99.0, **WIND) == 20.1
+
+
+def test_no_float_noise_on_the_wire():
+    # 0.1 * 3 is 0.30000000000000004 in binary floating point; the wire value
+    # must not carry that, the cloud rejects nothing but the logs get ugly.
+    assert grid.snap_to_grid(0.30000000000000004, **RAIN) == 0.3
+    assert repr(grid.snap_to_grid(0.7000000000000001, **RAIN)) == "0.7"
+
+
+def test_halfway_value_is_stable():
+    # Python rounds halves to even; either neighbour is a valid device value,
+    # what matters is that it lands on the grid.
+    result = grid.snap_to_grid(0.45, **RAIN)
+    assert result in (0.4, 0.5)
+    assert round(result * 10) == result * 10


### PR DESCRIPTION
## What

Adds a `number` platform with the two weather-skip thresholds from the watering-setting slot:

- `number.rain_threshold` (`rainAmount`) – rain amount above which a scheduled run is skipped.
- `number.wind_threshold` (`windSpeed`) – wind speed above which a run is skipped.

They sit in the same setting object as the rain/wind-sensing switches, but were not adjustable.

## Units

The device stores both as bare floats, and they are not unitless – the app converts them for display. Cross-checking the raw setting against what the app shows (thanks @woody6402 for the app-side readings):

- `rainAmount` is in **inches**: raw `0.5` shows as **~13 mm** (0.5 in = 12.7 mm).
- `windSpeed` is in **metres per second**: raw `8.2` shows as **~30 km/h** (8.2 m/s = 29.5 km/h).

The app offers mm/inches for rain and km/h/mph for wind, following one metric/imperial switch. It never shows m/s, so inches and m/s are the wire units.

## Why the entities publish mm and km/h

Declaring the wire units on the entity does not give a metric user the app's units. Unlike a sensor, a `number` does not follow the unit system: `homeassistant/components/number/__init__.py` reads `hass.config.units` only for `NumberDeviceClass.TEMPERATURE`, and the platform has no `suggested_unit_of_measurement`. Everything else keeps its native unit unless the user picks another one per entity. @woody6402 reported exactly this, and I reproduced it on 2026.7.2: the earlier revision of this PR showed `in` and `m/s` on a metric instance.

So the entities publish millimetres and km/h – the units the app shows most users – and convert to the device's inches / metres-per-second at the write boundary with the core converters (`DistanceConverter`, `SpeedConverter`). The wire unit stays an implementation detail of the cloud protocol. Anyone who prefers inches, mph or knots picks that unit in the entity settings: both device classes are in the number platform's converter table, so core converts display and input from there.

Input is snapped onto the device's own grid (0.1 in / 0.1 m/s, matching the app's gauge and slider) before it goes out, so a metric user typing 15 mm gets the 0.6 in the device supports instead of an off-grid 0.5906.

## Verification

Live on two devices, Home Assistant core 2026.7.2 with the metric unit system:

- Entities come up as `mm` and `km/h`, with the device ranges 2.54–25.4 mm and 7.92–72.36 km/h.
- Reading: raw `0.5` in renders as `12.7 mm`, raw `10` m/s renders as `36.0 km/h`.
- Writing 15 mm: the setting reads back `0.6` (snapped, not 0.5906) and the entity shows `15.24 mm`.
- Writing 30 km/h: the setting reads back `8.3` and the entity shows `29.88 km/h`.
- Both survived a full cloud poll – the cloud returned `0.6` / `8.3`, so this is a real device write, not a local echo. I then restored the original `0.5` / `10`.
- Five unit tests cover the pure grid helper: on-grid, off-grid, clamping, float noise, half-step.

## Dependency

`updateWateringSetting` rejects a partial body with code 6002, so writing one threshold needs the full-setting merge from #28. #28 is merged, and this branch is rebased onto main – the diff is the number platform only, with no borrowed commits.
