### PR TITLE
Add MQTT-connected diagnostic binary_sensor

### DIFF
--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -114,7 +114,7 @@ class MqttConnectedBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_name = "MQTT connected"
+    _attr_translation_key = "mqtt_connected"
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "mqtt_connected")

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
         entities.extend(
             [
                 OnlineBinarySensor(coordinator, sn),
+                MqttConnectedBinarySensor(coordinator, sn),
                 WateringBinarySensor(coordinator, sn),
                 RainSensingBinarySensor(coordinator, sn),
             ]
@@ -96,3 +97,28 @@ class RainSensingBinarySensor(IrrisenseEntity, BinarySensorEntity):
         rain = setting.get("rainSensing")
         weather = setting.get("weatherSensingRain")
         return bool(rain) and bool(weather)
+
+
+class MqttConnectedBinarySensor(IrrisenseEntity, BinarySensorEntity):
+    """Whether the integration's AWS IoT MQTT link is up.
+
+    Distinct from `online` / `session_conflict`, which reflect the REST/cloud
+    layer. Commands (setWorkMode, plan queries) ride MQTT, so this shows when
+    they can actually be delivered. AWS IoT allows one connection per Cognito
+    identity (last connect wins), so opening the iOS Aiper app evicts this
+    link until auto-recovery reconnects.
+
+    Reflects the client's connected belief: it can briefly read "on" during a
+    half-dead state where the socket is up but publishes time out.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "MQTT connected"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "mqtt_connected")
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.api.is_mqtt_connected()

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -57,6 +57,7 @@
       "last_zone": {"name": "Last watered zone"}
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connected"},
       "online": {"name": "Online"},
       "watering": {"name": "Watering"}
     },

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -57,6 +57,7 @@
       "last_zone": {"name": "Last watered zone"}
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connected"},
       "online": {"name": "Online"},
       "watering": {"name": "Watering"}
     },


### PR DESCRIPTION
## What

The integration's command channel (`setWorkMode`, plan queries) rides an AWS IoT MQTT link that is separate from the REST/cloud layer already surfaced by the `online` and `session_conflict` sensors. AWS IoT allows one connection per Cognito identity, so opening the phone app evicts the integration's MQTT link (last connect wins) until auto-recovery reconnects — during which commands silently fail to deliver.

This adds `binary_sensor.<device>_mqtt_connected` (device_class `connectivity`, diagnostic category) so that state is visible instead of log-only.

## Notes

- Source is `api.is_mqtt_connected()` — the client's connected belief. A half-dead socket (connected but publishes timing out) is not distinguished; catching that would need publish-timeout tracking, a possible follow-up.
- Diagnostic entity only, no behaviour change.
