### PR TITLE
Add a live spray-distance sensor (throw reach in metres)

### DIFF
--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -30,6 +30,7 @@ async def async_setup_entry(
                 WateringBinarySensor(coordinator, sn),
                 RainSensingBinarySensor(coordinator, sn),
                 SessionConflictBinarySensor(coordinator, sn),
+                LastRunFaultBinarySensor(coordinator, sn),
             ]
         )
     async_add_entities(entities)
@@ -122,3 +123,31 @@ class RainSensingBinarySensor(IrrisenseEntity, BinarySensorEntity):
         rain = setting.get("rainSensing")
         weather = setting.get("weatherSensingRain")
         return bool(rain) and bool(weather)
+
+
+# taskStatus == 2 is the app's ``fault`` outcome (device malfunction), distinct
+# from the normal non-completion reasons (manual stop, weather skip, …).
+_TASK_STATUS_FAULT = 2
+
+
+class LastRunFaultBinarySensor(IrrisenseEntity, BinarySensorEntity):
+    """On when the most recent run ended in a device fault (``taskStatus == 2``).
+
+    Lets an automation react to a failed run (e.g. a run that aborted with no
+    water delivered) without templating the ``last_run_status`` sensor.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_icon = "mdi:sprinkler-variant-alert"
+    _attr_translation_key = "last_run_fault"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_run_fault")
+        self._attr_name = "Last run fault"
+
+    @property
+    def is_on(self) -> bool | None:
+        last = self._latest_history_record
+        if last is None:
+            return None
+        return last.get("taskStatus") == _TASK_STATUS_FAULT

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -147,7 +147,6 @@ class LastRunFaultBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_run_fault")
-        self._attr_name = "Last run fault"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -125,16 +125,20 @@ class RainSensingBinarySensor(IrrisenseEntity, BinarySensorEntity):
         return bool(rain) and bool(weather)
 
 
-# taskStatus == 2 is the app's ``fault`` outcome (device malfunction), distinct
-# from the normal non-completion reasons (manual stop, weather skip, …).
-_TASK_STATUS_FAULT = 2
+# The two taskStatus outcomes that mean the device could not do its job:
+# ``2`` (fault / malfunction) and ``8`` (water shortage — no/insufficient
+# supply). The remaining non-completion codes (manual stop, weather skips,
+# task overlap, conflicts) are normal operation, not problems.
+_TASK_STATUS_PROBLEM = (2, 8)
 
 
 class LastRunFaultBinarySensor(IrrisenseEntity, BinarySensorEntity):
-    """On when the most recent run ended in a device fault (``taskStatus == 2``).
+    """On when the most recent run ended in a device problem.
 
-    Lets an automation react to a failed run (e.g. a run that aborted with no
-    water delivered) without templating the ``last_run_status`` sensor.
+    Fires on ``taskStatus`` fault (2) or water shortage (8) — e.g. a run that
+    aborted with no water delivered — so an automation can react without
+    templating the ``last_run_status`` sensor. Normal non-completions (manual
+    stop, weather skips) do not trip it.
     """
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
@@ -150,4 +154,4 @@ class LastRunFaultBinarySensor(IrrisenseEntity, BinarySensorEntity):
         last = self._latest_history_record
         if last is None:
             return None
-        return last.get("taskStatus") == _TASK_STATUS_FAULT
+        return last.get("taskStatus") in _TASK_STATUS_PROBLEM

--- a/custom_components/aiper_irrisense/entity.py
+++ b/custom_components/aiper_irrisense/entity.py
@@ -59,5 +59,21 @@ class IrrisenseEntity(CoordinatorEntity[IrrisenseCoordinator]):
         return m if isinstance(m, dict) else {}
 
     @property
+    def _latest_history_record(self) -> dict[str, Any] | None:
+        """Most recent watering-history record, or None.
+
+        The backend returns the record list under a version-dependent key
+        (``list`` / ``records`` / ``data``); this centralises the lookup the
+        history-backed sensors share.
+        """
+        history = self._slot.get("history")
+        if not isinstance(history, dict):
+            return None
+        items = history.get("list") or history.get("records") or history.get("data") or []
+        if isinstance(items, list) and items and isinstance(items[0], dict):
+            return items[0]
+        return None
+
+    @property
     def available(self) -> bool:
         return bool(self.coordinator.last_update_success)

--- a/custom_components/aiper_irrisense/geometry.py
+++ b/custom_components/aiper_irrisense/geometry.py
@@ -1,0 +1,32 @@
+"""Pure geometry helpers for the live spray target.
+
+The device reports the live spray target as Cartesian ``x`` / ``y`` in
+device-local units, with the stationary sprinkler head at the origin
+(0, 0). The throw distance is therefore the Euclidean radius
+``hypot(x, y)``.
+
+The protocol carries no physical unit for x/y — the app scales them only to
+fit the on-screen map, it never converts to metres. The unit below is an
+empirical calibration: one device's farthest line point read ~1319 units
+against a tape-measured reach of ~11 m, i.e. 1 unit ~= 1/3 inch (~8.47 mm),
+consistent with the device's imperial dosing. Treat the metre value as
+approximate; a second field measurement would tighten it.
+"""
+from __future__ import annotations
+
+import math
+
+# 1 device-local coordinate unit ~= 1/3 inch, empirically calibrated (~0.008467 m).
+_UNIT_METRES = 25.4 / 3 / 1000
+
+
+def spray_reach_m(x: object, y: object) -> float | None:
+    """Throw distance (metres) of the live spray target at ``x`` / ``y``.
+
+    Returns ``None`` for the origin (nothing sprayed) or non-numeric input.
+    """
+    if not (isinstance(x, (int, float)) and isinstance(y, (int, float))):
+        return None
+    if x == 0 and y == 0:
+        return None
+    return round(math.hypot(x, y) * _UNIT_METRES, 1)

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -549,10 +549,14 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
 class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
     """Water delivered during the most recent completed run.
 
-    Read from the newest watering-history record (``usedVolume``). Unlike the
+    Read from the newest watering-history record (``newWaterYield``). Unlike the
     lifetime total this is per-run, so it can drive per-run notifications or a
     comparison against a physical water meter. The unit follows the lifetime
     totals' convention (backend reports gallons; HA converts for metric users).
+
+    ``newWaterYield`` is the water the app itself shows per run; the sibling
+    ``usedVolume`` field is the potion/pesticide amount, not water, and reads 0
+    without a cartridge.
     """
 
     # No state_class: per-run snapshot, not a measurement stream — HA rejects
@@ -571,9 +575,7 @@ class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
         last = self._latest_history_record
         if last is None:
             return None
-        val = last.get("usedVolume")
-        if val is None:
-            val = last.get("used_volume")
+        val = last.get("newWaterYield")
         if isinstance(val, (int, float)):
             return float(val)
         return None

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -50,6 +50,8 @@ async def async_setup_entry(
                 TotalWateringEventsSensor(coordinator, sn),
                 LastWateringZoneSensor(coordinator, sn),
                 LastRunWaterSensor(coordinator, sn),
+                LastRunSavingSensor(coordinator, sn),
+                LastRunDurationSensor(coordinator, sn),
                 LastRunStatusSensor(coordinator, sn),
             ]
         )
@@ -597,6 +599,63 @@ TASK_STATUS_LABELS: dict[int, str] = {
     10: "conflict",
 }
 _TASK_STATUS_FALLBACK = "un_completed"
+
+
+class LastRunSavingSensor(IrrisenseEntity, SensorEntity):
+    """Water saved during the most recent run (``waterSavingAmount``).
+
+    Per-run counterpart to the lifetime ``total_water_saving`` total, read from
+    the newest history record. Same unit convention as the other water totals
+    (backend reports gallons; HA converts for metric users).
+    """
+
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
+    _attr_icon = "mdi:water-check"
+    _attr_translation_key = "last_run_saving"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_run_saving")
+        self._attr_name = "Last run water saved"
+
+    @property
+    def native_value(self) -> float | None:
+        last = self._latest_history_record
+        if last is None:
+            return None
+        val = last.get("waterSavingAmount")
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return float(val)
+        return None
+
+
+class LastRunDurationSensor(IrrisenseEntity, SensorEntity):
+    """Actual run time of the most recent run (``runTime``, minutes).
+
+    Verified against the record's planned ``duration`` on point zones: a
+    10-minute dose reports ``runTime`` 11, a 1-minute dose reports 2 — i.e.
+    the planned minutes plus ~1 of overhead. Line zones carry no planned
+    ``duration`` but the same ``runTime`` (minutes) still applies.
+    """
+
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "min"
+    _attr_icon = "mdi:timer-outline"
+    _attr_translation_key = "last_run_duration"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_run_duration")
+        self._attr_name = "Last run duration"
+
+    @property
+    def native_value(self) -> int | None:
+        last = self._latest_history_record
+        if last is None:
+            return None
+        val = last.get("runTime")
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return int(val)
+        return None
 
 
 class LastRunStatusSensor(IrrisenseEntity, SensorEntity):

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
                 ActiveProgressSensor(coordinator, sn),
                 ActiveRepairLayerSensor(coordinator, sn),
                 RemainingTimeSensor(coordinator, sn),
-                HeadAzimuthSensor(coordinator, sn),
+                HeadAngleSensor(coordinator, sn),
                 FirmwareSensor(coordinator, sn),
                 McuFirmwareSensor(coordinator, sn),
                 ValveFirmwareSensor(coordinator, sn),
@@ -322,24 +322,26 @@ class RemainingTimeSensor(_ActiveMetricBase):
         return None
 
 
-class HeadAzimuthSensor(_ActiveMetricBase):
-    """Compass bearing (0..360°) the sprinkler head currently points at.
+class HeadAngleSensor(_ActiveMetricBase):
+    """Rotation angle of the sprinkler head, 0..360°.
 
     The realTimeProgress stream reports the live spray target as Cartesian
-    ``x`` / ``y`` (device-relative, head at the origin) but no explicit head
-    angle. The azimuth is recovered as the bearing of that target,
-    ``(90 − atan2(y, x))`` normalised to 0..360° — the same relation the
+    ``x`` / ``y`` (head at the origin) but no explicit head angle. The angle
+    is recovered as ``(90 − atan2(y, x)) mod 360`` — the same relation the
     static map's ``rotate`` field (centi-degrees) follows, verified across
     ~50 map points on two devices.
+
+    Device-relative: 0° is the device's own +Y reference, **not** a compass
+    bearing — the data carries no geographic-North / real-world orientation.
     """
 
-    _attr_icon = "mdi:compass-outline"
+    _attr_icon = "mdi:angle-acute"
     _attr_native_unit_of_measurement = "°"
-    _attr_translation_key = "head_azimuth"
+    _attr_translation_key = "head_angle"
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
-        super().__init__(coordinator, sn, "head_azimuth")
-        self._attr_name = "Head azimuth"
+        super().__init__(coordinator, sn, "head_angle")
+        self._attr_name = "Head angle"
 
     @property
     def native_value(self) -> float | None:
@@ -352,8 +354,8 @@ class HeadAzimuthSensor(_ActiveMetricBase):
             return None
         if x == 0 and y == 0:
             return None
-        bearing = (90.0 - math.degrees(math.atan2(y, x))) % 360.0
-        return round(bearing, 1)
+        angle = (90.0 - math.degrees(math.atan2(y, x))) % 360.0
+        return round(angle, 1)
 
 
 # --------------------------------------------------------------------------- #

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -555,8 +555,9 @@ class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
     totals' convention (backend reports gallons; HA converts for metric users).
     """
 
+    # No state_class: per-run snapshot, not a measurement stream — HA rejects
+    # `measurement` on device_class `water` (expects total/total_increasing).
     _attr_device_class = SensorDeviceClass.WATER
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_icon = "mdi:water-sync"
     _attr_translation_key = "last_run_water"

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -50,6 +50,7 @@ async def async_setup_entry(
                 TotalWateringEventsSensor(coordinator, sn),
                 LastWateringZoneSensor(coordinator, sn),
                 LastRunWaterSensor(coordinator, sn),
+                LastRunStatusSensor(coordinator, sn),
             ]
         )
     async_add_entities(entities)
@@ -579,3 +580,48 @@ class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
         if isinstance(val, (int, float)):
             return float(val)
         return None
+
+
+# Outcome of a finished run, as coded on the watering-history record's
+# ``taskStatus`` field. Anything outside this table renders as ``un_completed``.
+TASK_STATUS_LABELS: dict[int, str] = {
+    1: "completed",
+    2: "fault",
+    3: "weather_wind",
+    4: "weather_rain",
+    5: "on_rain",
+    6: "overlap",
+    7: "manual_stop",
+    8: "water_shortage",
+    9: "manual_task",
+    10: "conflict",
+}
+_TASK_STATUS_FALLBACK = "un_completed"
+
+
+class LastRunStatusSensor(IrrisenseEntity, SensorEntity):
+    """Outcome label of the most recent watering-history record (``taskStatus``).
+
+    Surfaces why the last run ended — ``completed``, ``manual_stop``, a
+    weather skip, or ``fault`` — so the reason is available to automations
+    without polling the app.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(TASK_STATUS_LABELS.values()) + [_TASK_STATUS_FALLBACK]
+    _attr_icon = "mdi:clipboard-check-outline"
+    _attr_translation_key = "last_run_status"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_run_status")
+        self._attr_name = "Last run status"
+
+    @property
+    def native_value(self) -> str | None:
+        last = self._latest_history_record
+        if last is None:
+            return None
+        val = last.get("taskStatus")
+        if not isinstance(val, int) or isinstance(val, bool):
+            return None
+        return TASK_STATUS_LABELS.get(val, _TASK_STATUS_FALLBACK)

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -379,7 +379,6 @@ class SprayDistanceSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "spray_distance")
-        self._attr_name = "Spray distance"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -521,18 +521,9 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        history = self._slot.get("history")
-        if not isinstance(history, dict):
+        last = self._latest_history_record
+        if last is None:
             return None
-        items = (
-            history.get("list")
-            or history.get("records")
-            or history.get("data")
-            or []
-        )
-        if not (isinstance(items, list) and items and isinstance(items[0], dict)):
-            return None
-        last = items[0]
         region_id = last.get("regionId") or last.get("region_id") or last.get("mapId")
         if region_id is not None:
             try:
@@ -545,18 +536,14 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
-        history = self._slot.get("history")
-        if not isinstance(history, dict):
+        last = self._latest_history_record
+        if last is None:
             return None
-        items = history.get("list") or history.get("records") or history.get("data") or []
-        if isinstance(items, list) and items and isinstance(items[0], dict):
-            last = items[0]
-            return {
-                "start_time": last.get("startTime") or last.get("start_time"),
-                "duration_minutes": last.get("duration") or last.get("estimatedDuration"),
-                "depth_mm": last.get("depth") or last.get("waterYield"),
-            }
-        return None
+        return {
+            "start_time": last.get("startTime") or last.get("start_time"),
+            "duration_minutes": last.get("duration") or last.get("estimatedDuration"),
+            "depth_mm": last.get("depth") or last.get("waterYield"),
+        }
 
 
 class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
@@ -580,15 +567,12 @@ class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
 
     @property
     def native_value(self) -> float | None:
-        history = self._slot.get("history")
-        if not isinstance(history, dict):
+        last = self._latest_history_record
+        if last is None:
             return None
-        items = history.get("list") or history.get("records") or history.get("data") or []
-        if not (isinstance(items, list) and items and isinstance(items[0], dict)):
-            return None
-        val = items[0].get("usedVolume")
+        val = last.get("usedVolume")
         if val is None:
-            val = items[0].get("used_volume")
+            val = last.get("used_volume")
         if isinstance(val, (int, float)):
             return float(val)
         return None

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -8,6 +8,7 @@ Field names are confirmed from a live diagnostics dump:
 """
 from __future__ import annotations
 
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -38,6 +39,8 @@ async def async_setup_entry(
                 ActiveTotalSensor(coordinator, sn),
                 ActiveProgressSensor(coordinator, sn),
                 ActiveRepairLayerSensor(coordinator, sn),
+                RemainingTimeSensor(coordinator, sn),
+                HeadAzimuthSensor(coordinator, sn),
                 FirmwareSensor(coordinator, sn),
                 McuFirmwareSensor(coordinator, sn),
                 ValveFirmwareSensor(coordinator, sn),
@@ -46,6 +49,7 @@ async def async_setup_entry(
                 TotalWaterSavingSensor(coordinator, sn),
                 TotalWateringEventsSensor(coordinator, sn),
                 LastWateringZoneSensor(coordinator, sn),
+                LastRunWaterSensor(coordinator, sn),
             ]
         )
     async_add_entities(entities)
@@ -283,6 +287,75 @@ class ActiveRepairLayerSensor(_ActiveMetricBase):
         return None
 
 
+class RemainingTimeSensor(_ActiveMetricBase):
+    """Estimated seconds until the current run finishes (``total − elapsed``).
+
+    Reported only once the coordinator has back-solved a real run duration
+    (``duration_pending`` cleared). While the duration is still the 300s
+    placeholder we return None, so a dashboard shows "--:--" instead of
+    counting down a fake five minutes.
+    """
+
+    _attr_icon = "mdi:timer-sand-complete"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "s"
+    _attr_translation_key = "remaining_time"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "remaining_time")
+        self._attr_name = "Remaining time"
+
+    @property
+    def native_value(self) -> int | None:
+        live = self._live()
+        if not live or live.get("duration_pending"):
+            return None
+        total = live.get("duration_seconds")
+        elapsed = live.get("time_sec")
+        if (
+            isinstance(total, (int, float))
+            and isinstance(elapsed, (int, float))
+            and total > 0
+        ):
+            return int(max(0, total - elapsed))
+        return None
+
+
+class HeadAzimuthSensor(_ActiveMetricBase):
+    """Compass bearing (0..360°) the sprinkler head currently points at.
+
+    The realTimeProgress stream reports the live spray target as Cartesian
+    ``x`` / ``y`` (device-relative, head at the origin) but no explicit head
+    angle. The azimuth is recovered as the bearing of that target,
+    ``(90 − atan2(y, x))`` normalised to 0..360° — the same relation the
+    static map's ``rotate`` field (centi-degrees) follows, verified across
+    ~50 map points on two devices.
+    """
+
+    _attr_icon = "mdi:compass-outline"
+    _attr_native_unit_of_measurement = "°"
+    _attr_translation_key = "head_azimuth"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "head_azimuth")
+        self._attr_name = "Head azimuth"
+
+    @property
+    def native_value(self) -> float | None:
+        live = self._live()
+        if not live:
+            return None
+        x = live.get("x")
+        y = live.get("y")
+        if not (isinstance(x, (int, float)) and isinstance(y, (int, float))):
+            return None
+        if x == 0 and y == 0:
+            return None
+        bearing = (90.0 - math.degrees(math.atan2(y, x))) % 360.0
+        return round(bearing, 1)
+
+
 # --------------------------------------------------------------------------- #
 # Firmware sensors
 # --------------------------------------------------------------------------- #
@@ -481,4 +554,39 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
                 "duration_minutes": last.get("duration") or last.get("estimatedDuration"),
                 "depth_mm": last.get("depth") or last.get("waterYield"),
             }
+        return None
+
+
+class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
+    """Water delivered during the most recent completed run.
+
+    Read from the newest watering-history record (``usedVolume``). Unlike the
+    lifetime total this is per-run, so it can drive per-run notifications or a
+    comparison against a physical water meter. The unit follows the lifetime
+    totals' convention (backend reports gallons; HA converts for metric users).
+    """
+
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
+    _attr_icon = "mdi:water-sync"
+    _attr_translation_key = "last_run_water"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "last_run_water")
+        self._attr_name = "Last run water"
+
+    @property
+    def native_value(self) -> float | None:
+        history = self._slot.get("history")
+        if not isinstance(history, dict):
+            return None
+        items = history.get("list") or history.get("records") or history.get("data") or []
+        if not (isinstance(items, list) and items and isinstance(items[0], dict)):
+            return None
+        val = items[0].get("usedVolume")
+        if val is None:
+            val = items[0].get("used_volume")
+        if isinstance(val, (int, float)):
+            return float(val)
         return None

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -307,7 +307,6 @@ class RemainingTimeSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "remaining_time")
-        self._attr_name = "Remaining time"
 
     @property
     def native_value(self) -> int | None:
@@ -344,7 +343,6 @@ class HeadAngleSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "head_angle")
-        self._attr_name = "Head angle"
 
     @property
     def native_value(self) -> float | None:
@@ -571,7 +569,6 @@ class LastRunWaterSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_run_water")
-        self._attr_name = "Last run water"
 
     @property
     def native_value(self) -> float | None:
@@ -616,7 +613,6 @@ class LastRunSavingSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_run_saving")
-        self._attr_name = "Last run water saved"
 
     @property
     def native_value(self) -> float | None:
@@ -645,7 +641,6 @@ class LastRunDurationSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_run_duration")
-        self._attr_name = "Last run duration"
 
     @property
     def native_value(self) -> int | None:
@@ -673,7 +668,6 @@ class LastRunStatusSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_run_status")
-        self._attr_name = "Last run status"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -14,13 +14,14 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfVolume
+from homeassistant.const import EntityCategory, UnitOfLength, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import IrrisenseCoordinator
 from .entity import IrrisenseEntity
+from .geometry import spray_reach_m
 
 
 async def async_setup_entry(
@@ -41,6 +42,7 @@ async def async_setup_entry(
                 ActiveRepairLayerSensor(coordinator, sn),
                 RemainingTimeSensor(coordinator, sn),
                 HeadAngleSensor(coordinator, sn),
+                SprayDistanceSensor(coordinator, sn),
                 FirmwareSensor(coordinator, sn),
                 McuFirmwareSensor(coordinator, sn),
                 ValveFirmwareSensor(coordinator, sn),
@@ -357,6 +359,34 @@ class HeadAngleSensor(_ActiveMetricBase):
             return None
         angle = (90.0 - math.degrees(math.atan2(y, x))) % 360.0
         return round(angle, 1)
+
+
+class SprayDistanceSensor(_ActiveMetricBase):
+    """Live throw distance of the water, in metres.
+
+    The realTimeProgress stream reports the spray target as Cartesian
+    ``x`` / ``y`` (head at the origin); the reach is the radius
+    ``hypot(x, y)`` scaled to metres. The protocol carries no unit, so the
+    metre value uses an empirical calibration (see ``geometry.py``) and is
+    approximate. None when idle.
+    """
+
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.METERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:sprinkler-variant"
+    _attr_translation_key = "spray_distance"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "spray_distance")
+        self._attr_name = "Spray distance"
+
+    @property
+    def native_value(self) -> float | None:
+        live = self._live()
+        if not live:
+            return None
+        return spray_reach_m(live.get("x"), live.get("y"))
 
 
 # --------------------------------------------------------------------------- #

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -51,7 +51,7 @@
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
       "remaining_time": {"name": "Remaining time"},
-      "head_azimuth": {"name": "Head azimuth"},
+      "head_angle": {"name": "Head angle"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -57,12 +57,29 @@
       "water_week": {"name": "Water usage this week"},
       "water_month": {"name": "Water usage this month"},
       "last_zone": {"name": "Last watered zone"},
-      "last_run_water": {"name": "Last run water"}
+      "last_run_water": {"name": "Last run water"},
+      "last_run_status": {
+        "name": "Last run status",
+        "state": {
+          "completed": "Completed",
+          "fault": "Fault",
+          "weather_wind": "Skipped – wind",
+          "weather_rain": "Skipped – rain forecast",
+          "on_rain": "Skipped – raining",
+          "overlap": "Skipped – overlap",
+          "manual_stop": "Stopped manually",
+          "water_shortage": "Stopped – no water",
+          "manual_task": "Skipped – manual task",
+          "conflict": "Skipped – conflict",
+          "un_completed": "Incomplete"
+        }
+      }
     },
     "binary_sensor": {
       "online": {"name": "Online"},
       "watering": {"name": "Watering"},
-      "session_conflict": {"name": "Session conflict"}
+      "session_conflict": {"name": "Session conflict"},
+      "last_run_fault": {"name": "Last run fault"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -58,6 +58,8 @@
       "water_month": {"name": "Water usage this month"},
       "last_zone": {"name": "Last watered zone"},
       "last_run_water": {"name": "Last run water"},
+      "last_run_saving": {"name": "Last run water saved"},
+      "last_run_duration": {"name": "Last run duration"},
       "last_run_status": {
         "name": "Last run status",
         "state": {

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -52,6 +52,7 @@
       "active_repair_layer": {"name": "Coverage passes"},
       "remaining_time": {"name": "Remaining time"},
       "head_angle": {"name": "Head angle"},
+      "spray_distance": {"name": "Spray distance"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -50,11 +50,14 @@
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
+      "remaining_time": {"name": "Remaining time"},
+      "head_azimuth": {"name": "Head azimuth"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},
       "water_month": {"name": "Water usage this month"},
-      "last_zone": {"name": "Last watered zone"}
+      "last_zone": {"name": "Last watered zone"},
+      "last_run_water": {"name": "Last run water"}
     },
     "binary_sensor": {
       "online": {"name": "Online"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -51,7 +51,7 @@
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
       "remaining_time": {"name": "Remaining time"},
-      "head_azimuth": {"name": "Head azimuth"},
+      "head_angle": {"name": "Head angle"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -57,12 +57,29 @@
       "water_week": {"name": "Water usage this week"},
       "water_month": {"name": "Water usage this month"},
       "last_zone": {"name": "Last watered zone"},
-      "last_run_water": {"name": "Last run water"}
+      "last_run_water": {"name": "Last run water"},
+      "last_run_status": {
+        "name": "Last run status",
+        "state": {
+          "completed": "Completed",
+          "fault": "Fault",
+          "weather_wind": "Skipped – wind",
+          "weather_rain": "Skipped – rain forecast",
+          "on_rain": "Skipped – raining",
+          "overlap": "Skipped – overlap",
+          "manual_stop": "Stopped manually",
+          "water_shortage": "Stopped – no water",
+          "manual_task": "Skipped – manual task",
+          "conflict": "Skipped – conflict",
+          "un_completed": "Incomplete"
+        }
+      }
     },
     "binary_sensor": {
       "online": {"name": "Online"},
       "watering": {"name": "Watering"},
-      "session_conflict": {"name": "Session conflict"}
+      "session_conflict": {"name": "Session conflict"},
+      "last_run_fault": {"name": "Last run fault"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -58,6 +58,8 @@
       "water_month": {"name": "Water usage this month"},
       "last_zone": {"name": "Last watered zone"},
       "last_run_water": {"name": "Last run water"},
+      "last_run_saving": {"name": "Last run water saved"},
+      "last_run_duration": {"name": "Last run duration"},
       "last_run_status": {
         "name": "Last run status",
         "state": {

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -52,6 +52,7 @@
       "active_repair_layer": {"name": "Coverage passes"},
       "remaining_time": {"name": "Remaining time"},
       "head_angle": {"name": "Head angle"},
+      "spray_distance": {"name": "Spray distance"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -50,11 +50,14 @@
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
+      "remaining_time": {"name": "Remaining time"},
+      "head_azimuth": {"name": "Head azimuth"},
       "firmware": {"name": "Firmware version"},
       "water_today": {"name": "Water usage today"},
       "water_week": {"name": "Water usage this week"},
       "water_month": {"name": "Water usage this month"},
-      "last_zone": {"name": "Last watered zone"}
+      "last_zone": {"name": "Last watered zone"},
+      "last_run_water": {"name": "Last run water"}
     },
     "binary_sensor": {
       "online": {"name": "Online"},

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,45 @@
+"""Unit tests for the pure spray-reach geometry helper.
+
+`geometry.py` is stdlib-only (no homeassistant import), so we file-load it
+directly to avoid executing the package __init__.py (which imports HA).
+"""
+import importlib.util
+import pathlib
+
+_GEO_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "custom_components" / "aiper_irrisense" / "geometry.py"
+)
+_spec = importlib.util.spec_from_file_location("geometry", _GEO_PATH)
+geo = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(geo)
+
+
+def test_origin_is_none():
+    # Head at the origin — nothing is being sprayed.
+    assert geo.spray_reach_m(0, 0) is None
+    assert geo.spray_reach_m(0.0, 0.0) is None
+
+
+def test_known_reach_axis():
+    # ~1319 units measured against a ~11 m tape reach (empirical calibration).
+    assert geo.spray_reach_m(1319, 0) == 11.2
+    assert geo.spray_reach_m(0, 1319) == 11.2  # radius, axis-independent
+
+
+def test_known_reach_diagonal():
+    # 3-4-5 triangle scaled ×100 -> radius 500 units.
+    assert geo.spray_reach_m(300, 400) == 4.2
+
+
+def test_negative_coordinates_use_magnitude():
+    # x/y are signed ground coordinates; reach is the magnitude.
+    assert geo.spray_reach_m(-300, -400) == 4.2
+    assert geo.spray_reach_m(-1319, 0) == 11.2
+
+
+def test_non_numeric_is_none():
+    assert geo.spray_reach_m(None, 5) is None
+    assert geo.spray_reach_m(5, None) is None
+    assert geo.spray_reach_m("x", 5) is None
+    assert geo.spray_reach_m(None, None) is None


### PR DESCRIPTION
Adds a per-device `spray_distance` sensor: the live water throw distance in metres, derived from the realTimeProgress spray target.

**How it works**

The stream reports the spray target as Cartesian `x` / `y` with the stationary head at the origin, so the reach is the radius `hypot(x, y)`. The protocol carries no physical unit for `x` / `y` (they are only scaled to fit the app's map), so the metre value uses an empirical 1-unit ≈ 1/3-inch calibration and is approximate – it is documented in `geometry.py`. The sensor mirrors the existing `head_angle` sensor: a live per-run metric that reads `None` when idle.

**Contents**

- `geometry.py` – pure `spray_reach_m(x, y)` helper, with unit tests
- `SprayDistanceSensor` in `sensor.py` (device_class distance, metres)
- translations

**Stacked off #42**

This branches off #42 (derived live sensors) because it reuses the `_ActiveMetricBase` live-metric base added there. The diff therefore also shows #42's commits; only the final `feat(sensor): add live spray-distance sensor` commit is new here. I will rebase onto main once #42 lands – for now, review just that commit and `geometry.py`.
