### PR TITLE
Add de/fr/es/it/pt/nl translations, and let translation_key drive names

### DIFF
--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -42,7 +42,6 @@ class OnlineBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "online")
-        self._attr_name = "Online"
 
     @property
     def is_on(self) -> bool:
@@ -88,7 +87,6 @@ class WateringBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "watering")
-        self._attr_name = "Watering"
 
     @property
     def is_on(self) -> bool:
@@ -112,7 +110,6 @@ class RainSensingBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "rain_sensing")
-        self._attr_name = "Rain sensing active"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/aiper_irrisense/binary_sensor.py
+++ b/custom_components/aiper_irrisense/binary_sensor.py
@@ -73,7 +73,6 @@ class SessionConflictBinarySensor(IrrisenseEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "session_conflict")
-        self._attr_name = "Session conflict"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/aiper_irrisense/button.py
+++ b/custom_components/aiper_irrisense/button.py
@@ -57,7 +57,6 @@ class StartWateringButton(IrrisenseEntity, ButtonEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "start_watering")
-        self._attr_name = "Start watering"
 
     async def async_press(self) -> None:
         zone_id = self.coordinator.get_zone_selection(self._sn)
@@ -114,7 +113,6 @@ class StopWateringButton(IrrisenseEntity, ButtonEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "stop_watering")
-        self._attr_name = "Stop watering"
 
     async def async_press(self) -> None:
         # Prefer the device's own "what's running now" — the selection

--- a/custom_components/aiper_irrisense/select.py
+++ b/custom_components/aiper_irrisense/select.py
@@ -72,7 +72,6 @@ class NozzleTypeSelect(IrrisenseEntity, SelectEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "nozzle_type")
-        self._attr_name = "Nozzle type"
         self._attr_options = list(NOZZLE_TYPE_LABELS.values())
 
     @property
@@ -133,7 +132,6 @@ class ZoneSelect(IrrisenseEntity, SelectEntity, RestoreEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "watering_zone")
-        self._attr_name = "Watering zone"
         self._refresh_options()
 
     # ----- Options ---------------------------------------------------------
@@ -221,11 +219,9 @@ class DoseSelect(IrrisenseEntity, SelectEntity, RestoreEntity):
         """Rewrite options + name + icon to match the zone type."""
         self._attr_options = dose_options_for_region_type(region_type)
         if region_type == REGION_TYPE_POINT:
-            self._attr_name = "Duration"
             self._attr_icon = "mdi:timer-outline"
             self._attr_translation_key = "watering_duration"
         else:
-            self._attr_name = "Dose"
             self._attr_icon = "mdi:water"
             self._attr_translation_key = "watering_dose"
 

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -70,7 +70,6 @@ class ActiveZoneSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "active_zone")
-        self._attr_name = "Active zone"
 
     @property
     def native_value(self) -> str | None:
@@ -169,7 +168,6 @@ class ActiveElapsedSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "active_elapsed")
-        self._attr_name = "Elapsed seconds"
 
     @property
     def native_value(self) -> int | None:
@@ -196,7 +194,6 @@ class ActiveTotalSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "active_total")
-        self._attr_name = "Run total seconds"
 
     @property
     def native_value(self) -> int | None:
@@ -225,7 +222,6 @@ class ActiveProgressSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "active_progress")
-        self._attr_name = "Progress"
 
     @property
     def native_value(self) -> float | None:
@@ -270,7 +266,6 @@ class ActiveRepairLayerSensor(_ActiveMetricBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "active_repair_layer")
-        self._attr_name = "Coverage passes"
 
     @property
     def native_value(self) -> int | None:
@@ -315,7 +310,6 @@ class FirmwareSensor(_FirmwareBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "firmware")
-        self._attr_name = "Firmware version"
 
 
 class McuFirmwareSensor(_FirmwareBase):
@@ -324,7 +318,6 @@ class McuFirmwareSensor(_FirmwareBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "firmware_mcu")
-        self._attr_name = "MCU firmware"
 
 
 class ValveFirmwareSensor(_FirmwareBase):
@@ -333,7 +326,6 @@ class ValveFirmwareSensor(_FirmwareBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "firmware_valve")
-        self._attr_name = "Valve firmware"
 
 
 # --------------------------------------------------------------------------- #
@@ -350,7 +342,6 @@ class WifiRssiSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "wifi_rssi")
-        self._attr_name = "WiFi signal"
 
     @property
     def native_value(self) -> int | None:
@@ -383,7 +374,6 @@ class TotalWaterYieldSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "total_water_yield")
-        self._attr_name = "Total water delivered"
 
     @property
     def native_value(self) -> float | None:
@@ -404,7 +394,6 @@ class TotalWaterSavingSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "total_water_saving")
-        self._attr_name = "Total water saved"
 
     @property
     def native_value(self) -> float | None:
@@ -424,7 +413,6 @@ class TotalWateringEventsSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "total_events")
-        self._attr_name = "Watering events"
 
     @property
     def native_value(self) -> int | None:
@@ -442,7 +430,6 @@ class LastWateringZoneSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "last_zone")
-        self._attr_name = "Last watered zone"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Schedules"},
       "active_zone": {"name": "Active zone"},
       "current_dose": {"name": "Current dose"},
       "active_elapsed": {"name": "Elapsed seconds"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connected"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Rain sensing active"},
       "watering": {"name": "Watering"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Pesticide reminder"},
       "reminder_task": {"name": "Task reminder"},
       "reminder_water_shortage": {"name": "Water shortage reminder"}
+    },
+    "image": {
+      "zone_map": {"name": "Zone map"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -38,7 +38,9 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "weather_refresh_hours": "Weather refresh (hours)",
+          "enable_experimental_sensors": "Enable experimental sensors (pesticide usage, skip history)"
         }
       }
     }
@@ -46,20 +48,64 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Active zone"},
+      "current_dose": {"name": "Current dose"},
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
+      "remaining_time": {"name": "Remaining time"},
+      "head_angle": {"name": "Head angle"},
+      "spray_distance": {"name": "Spray distance"},
       "firmware": {"name": "Firmware version"},
-      "water_today": {"name": "Water usage today"},
-      "water_week": {"name": "Water usage this week"},
-      "water_month": {"name": "Water usage this month"},
-      "last_zone": {"name": "Last watered zone"}
+      "firmware_mcu": {"name": "MCU firmware"},
+      "firmware_valve": {"name": "Valve firmware"},
+      "wifi_rssi": {"name": "WiFi signal"},
+      "total_water_yield": {"name": "Total water delivered"},
+      "total_water_saving": {"name": "Total water saved"},
+      "total_events": {"name": "Watering events"},
+      "last_zone": {"name": "Last watered zone"},
+      "last_skip": {"name": "Last skip reason"},
+      "pesticide_usage": {"name": "Pesticide usage zones"},
+      "last_run_water": {"name": "Last run water"},
+      "last_run_saving": {"name": "Last run water saved"},
+      "last_run_duration": {"name": "Last run duration"},
+      "last_run_status": {
+        "name": "Last run status",
+        "state": {
+          "completed": "Completed",
+          "fault": "Fault",
+          "weather_wind": "Skipped – wind",
+          "weather_rain": "Skipped – rain forecast",
+          "on_rain": "Skipped – raining",
+          "overlap": "Skipped – overlap",
+          "manual_stop": "Stopped manually",
+          "water_shortage": "Stopped – no water",
+          "manual_task": "Skipped – manual task",
+          "conflict": "Skipped – conflict",
+          "un_completed": "Incomplete"
+        }
+      }
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Rain sensing active"},
       "watering": {"name": "Watering"},
-      "session_conflict": {"name": "Session conflict"}
+      "session_conflict": {"name": "Session conflict"},
+      "last_run_fault": {"name": "Last run fault"}
+    },
+    "number": {
+      "watering_depth": {"name": "Watering depth"},
+      "rain_threshold": {"name": "Rain threshold"},
+      "wind_threshold": {"name": "Wind threshold"},
+      "watering_duration": {"name": "Watering duration"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Rain sensing"},
+      "wind_sensing_switch": {"name": "Wind sensing"},
+      "reminder_drainage": {"name": "Drainage reminder"},
+      "reminder_pesticide": {"name": "Pesticide reminder"},
+      "reminder_task": {"name": "Task reminder"},
+      "reminder_water_shortage": {"name": "Water shortage reminder"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/switch.py
+++ b/custom_components/aiper_irrisense/switch.py
@@ -224,7 +224,7 @@ class _SettingSwitch(IrrisenseEntity, SwitchEntity):
             )
         if not ok:
             raise HomeAssistantError(
-                f"Failed to update {self._attr_name or self._setting_key}"
+                f"Failed to update {self.name or self._setting_key}"
             )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -242,7 +242,6 @@ class RainSensingSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "rain_sensing_switch")
-        self._attr_name = "Rain sensing"
 
 
 class WindSensingSwitch(_SettingSwitch):
@@ -253,7 +252,6 @@ class WindSensingSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "wind_sensing_switch")
-        self._attr_name = "Wind sensing"
 
 
 class DrainageReminderSwitch(_SettingSwitch):
@@ -266,7 +264,6 @@ class DrainageReminderSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "reminder_drainage")
-        self._attr_name = "Drainage reminder"
 
 
 class PesticideReminderSwitch(_SettingSwitch):
@@ -279,7 +276,6 @@ class PesticideReminderSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "reminder_pesticide")
-        self._attr_name = "Pesticide reminder"
 
 
 class TaskReminderSwitch(_SettingSwitch):
@@ -292,7 +288,6 @@ class TaskReminderSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "reminder_task")
-        self._attr_name = "Task reminder"
 
 
 class WaterShortageReminderSwitch(_SettingSwitch):
@@ -305,4 +300,3 @@ class WaterShortageReminderSwitch(_SettingSwitch):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "reminder_water_shortage")
-        self._attr_name = "Water shortage reminder"

--- a/custom_components/aiper_irrisense/translations/de.json
+++ b/custom_components/aiper_irrisense/translations/de.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Zeitpläne"},
       "active_zone": {"name": "Aktive Zone"},
       "current_dose": {"name": "Aktuelle Dosis"},
       "active_elapsed": {"name": "Vergangene Sekunden"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT verbunden"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Regensensor aktiv"},
       "watering": {"name": "Bewässerung"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Erinnerung Pflanzenschutzmittel"},
       "reminder_task": {"name": "Erinnerung Bewässerungsaufgabe"},
       "reminder_water_shortage": {"name": "Erinnerung Wassermangel"}
+    },
+    "image": {
+      "zone_map": {"name": "Zonenkarte"}
     },
     "select": {
       "nozzle_type": {"name": "Düsentyp"},

--- a/custom_components/aiper_irrisense/translations/de.json
+++ b/custom_components/aiper_irrisense/translations/de.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Mit Ihrem Aiper-Konto anmelden. Es werden nur IrriSense-Geräte (Seriennummer-Präfix WR / WG / WC / WL) hinzugefügt.",
+        "data": {
+          "username": "E-Mail-Adresse",
+          "password": "Passwort",
+          "region": "Region"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Aiper Irrisense erneut anmelden",
+        "description": "Die gespeicherten Zugangsdaten sind nicht mehr gültig. Bitte geben Sie Ihr Passwort erneut ein.",
+        "data": {
+          "password": "Passwort"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Ungültige Zugangsdaten.",
+      "cannot_connect": "Verbindung zur Aiper-Cloud fehlgeschlagen.",
+      "no_devices": "Auf diesem Konto wurden keine IrriSense-Geräte (WR / WG / WC / WL) gefunden.",
+      "unknown": "Unerwarteter Fehler."
+    },
+    "abort": {
+      "already_configured": "Dieses Konto ist bereits eingerichtet."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Aiper Irrisense Optionen",
+        "data": {
+          "enable_mqtt": "MQTT aktivieren (Echtzeit-Updates)",
+          "mqtt_debug": "Alle MQTT-Nachrichten protokollieren (nur Debug)",
+          "poll_interval": "Abfrageintervall (Sekunden)",
+          "map_refresh_hours": "Aktualisierungsintervall Zonenkarte (Stunden)",
+          "history_refresh_hours": "Aktualisierung Verlauf / Statistik (Stunden)",
+          "reminder_refresh_hours": "Aktualisierung Düse / Erinnerung (Stunden)",
+          "weather_refresh_hours": "Wetter-Aktualisierung (Stunden)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Aktive Zone"},
+      "active_elapsed": {"name": "Vergangene Sekunden"},
+      "active_total": {"name": "Laufdauer gesamt (Sekunden)"},
+      "active_progress": {"name": "Fortschritt"},
+      "active_repair_layer": {"name": "Abdeckungsdurchgänge"},
+      "remaining_time": {"name": "Verbleibende Zeit"},
+      "head_angle": {"name": "Kopfwinkel"},
+      "spray_distance": {"name": "Wurfweite"},
+      "firmware": {"name": "Firmware-Version"},
+      "water_today": {"name": "Wasserverbrauch heute"},
+      "water_week": {"name": "Wasserverbrauch diese Woche"},
+      "water_month": {"name": "Wasserverbrauch diesen Monat"},
+      "last_zone": {"name": "Zuletzt bewässerte Zone"},
+      "last_run_water": {"name": "Wasser letzter Lauf"},
+      "last_run_saving": {"name": "Wasserersparnis letzter Lauf"},
+      "last_run_duration": {"name": "Dauer letzter Lauf"},
+      "last_run_status": {
+        "name": "Status letzter Lauf",
+        "state": {
+          "completed": "Abgeschlossen",
+          "fault": "Störung",
+          "weather_wind": "Übersprungen – Wind",
+          "weather_rain": "Übersprungen – Regenvorhersage",
+          "on_rain": "Übersprungen – Regen",
+          "overlap": "Übersprungen – Überschneidung",
+          "manual_stop": "Manuell gestoppt",
+          "water_shortage": "Gestoppt – kein Wasser",
+          "manual_task": "Übersprungen – manuelle Aufgabe",
+          "conflict": "Übersprungen – Konflikt",
+          "un_completed": "Unvollständig"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "Online"},
+      "watering": {"name": "Bewässerung"},
+      "session_conflict": {"name": "Sitzungskonflikt"},
+      "last_run_fault": {"name": "Störung letzter Lauf"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Düsentyp"},
+      "watering_zone": {"name": "Bewässerungszone"},
+      "watering_dose": {"name": "Dosis"},
+      "watering_duration": {"name": "Dauer"}
+    },
+    "button": {
+      "start_watering": {"name": "Bewässerung starten"},
+      "stop_watering": {"name": "Bewässerung stoppen"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Zone starten",
+      "description": "Bewässerung einer bestimmten Zone starten."
+    },
+    "stop_zone": {
+      "name": "Zone stoppen",
+      "description": "Bewässerung einer bestimmten Zone stoppen."
+    },
+    "query_work_info": {
+      "name": "Arbeitsinfo abfragen",
+      "description": "Das Gerät auffordern, sofort seinen aktuellen Arbeitsstatus zu senden."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/de.json
+++ b/custom_components/aiper_irrisense/translations/de.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Aktive Zone"},
+      "current_dose": {"name": "Aktuelle Dosis"},
       "active_elapsed": {"name": "Vergangene Sekunden"},
       "active_total": {"name": "Laufdauer gesamt (Sekunden)"},
       "active_progress": {"name": "Fortschritt"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Kopfwinkel"},
       "spray_distance": {"name": "Wurfweite"},
       "firmware": {"name": "Firmware-Version"},
-      "water_today": {"name": "Wasserverbrauch heute"},
-      "water_week": {"name": "Wasserverbrauch diese Woche"},
-      "water_month": {"name": "Wasserverbrauch diesen Monat"},
+      "firmware_mcu": {"name": "MCU-Firmware"},
+      "firmware_valve": {"name": "Ventil-Firmware"},
+      "wifi_rssi": {"name": "WLAN-Signal"},
+      "total_water_yield": {"name": "Wasser gesamt"},
+      "total_water_saving": {"name": "Wasser gespart gesamt"},
+      "total_events": {"name": "Bewässerungsvorgänge"},
       "last_zone": {"name": "Zuletzt bewässerte Zone"},
       "last_run_water": {"name": "Wasser letzter Lauf"},
       "last_run_saving": {"name": "Wasserersparnis letzter Lauf"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Regensensor aktiv"},
       "watering": {"name": "Bewässerung"},
       "session_conflict": {"name": "Sitzungskonflikt"},
       "last_run_fault": {"name": "Störung letzter Lauf"}
+    },
+    "number": {
+      "watering_depth": {"name": "Bewässerungstiefe"},
+      "watering_duration": {"name": "Bewässerungsdauer"}
     },
     "select": {
       "nozzle_type": {"name": "Düsentyp"},

--- a/custom_components/aiper_irrisense/translations/de.json
+++ b/custom_components/aiper_irrisense/translations/de.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Aktualisierungsintervall Zonenkarte (Stunden)",
           "history_refresh_hours": "Aktualisierung Verlauf / Statistik (Stunden)",
           "reminder_refresh_hours": "Aktualisierung Düse / Erinnerung (Stunden)",
-          "weather_refresh_hours": "Wetter-Aktualisierung (Stunden)"
+          "weather_refresh_hours": "Wetter-Aktualisierung (Stunden)",
+          "enable_experimental_sensors": "Experimentelle Sensoren aktivieren (Pflanzenschutzmittel-Nutzung, Übersprung-Verlauf)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Wasser gespart gesamt"},
       "total_events": {"name": "Bewässerungsvorgänge"},
       "last_zone": {"name": "Zuletzt bewässerte Zone"},
+      "last_skip": {"name": "Grund des letzten Übersprungs"},
+      "pesticide_usage": {"name": "Zonen mit Pflanzenschutzmittel"},
       "last_run_water": {"name": "Wasser letzter Lauf"},
       "last_run_saving": {"name": "Wasserersparnis letzter Lauf"},
       "last_run_duration": {"name": "Dauer letzter Lauf"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Bewässerungstiefe"},
+      "rain_threshold": {"name": "Regenschwelle"},
+      "wind_threshold": {"name": "Windschwelle"},
       "watering_duration": {"name": "Bewässerungsdauer"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Regenerkennung"},
+      "wind_sensing_switch": {"name": "Winderkennung"},
+      "reminder_drainage": {"name": "Erinnerung Entwässerung"},
+      "reminder_pesticide": {"name": "Erinnerung Pflanzenschutzmittel"},
+      "reminder_task": {"name": "Erinnerung Bewässerungsaufgabe"},
+      "reminder_water_shortage": {"name": "Erinnerung Wassermangel"}
     },
     "select": {
       "nozzle_type": {"name": "Düsentyp"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -38,7 +38,8 @@
           "poll_interval": "Poll interval (seconds)",
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
-          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)"
+          "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
+          "weather_refresh_hours": "Weather refresh (hours)"
         }
       }
     }
@@ -46,20 +47,52 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Active zone"},
+      "current_dose": {"name": "Current dose"},
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
       "active_repair_layer": {"name": "Coverage passes"},
+      "remaining_time": {"name": "Remaining time"},
+      "head_angle": {"name": "Head angle"},
+      "spray_distance": {"name": "Spray distance"},
       "firmware": {"name": "Firmware version"},
-      "water_today": {"name": "Water usage today"},
-      "water_week": {"name": "Water usage this week"},
-      "water_month": {"name": "Water usage this month"},
-      "last_zone": {"name": "Last watered zone"}
+      "firmware_mcu": {"name": "MCU firmware"},
+      "firmware_valve": {"name": "Valve firmware"},
+      "wifi_rssi": {"name": "WiFi signal"},
+      "total_water_yield": {"name": "Total water delivered"},
+      "total_water_saving": {"name": "Total water saved"},
+      "total_events": {"name": "Watering events"},
+      "last_zone": {"name": "Last watered zone"},
+      "last_run_water": {"name": "Last run water"},
+      "last_run_saving": {"name": "Last run water saved"},
+      "last_run_duration": {"name": "Last run duration"},
+      "last_run_status": {
+        "name": "Last run status",
+        "state": {
+          "completed": "Completed",
+          "fault": "Fault",
+          "weather_wind": "Skipped – wind",
+          "weather_rain": "Skipped – rain forecast",
+          "on_rain": "Skipped – raining",
+          "overlap": "Skipped – overlap",
+          "manual_stop": "Stopped manually",
+          "water_shortage": "Stopped – no water",
+          "manual_task": "Skipped – manual task",
+          "conflict": "Skipped – conflict",
+          "un_completed": "Incomplete"
+        }
+      }
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Rain sensing active"},
       "watering": {"name": "Watering"},
-      "session_conflict": {"name": "Session conflict"}
+      "session_conflict": {"name": "Session conflict"},
+      "last_run_fault": {"name": "Last run fault"}
+    },
+    "number": {
+      "watering_depth": {"name": "Watering depth"},
+      "watering_duration": {"name": "Watering duration"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Schedules"},
       "active_zone": {"name": "Active zone"},
       "current_dose": {"name": "Current dose"},
       "active_elapsed": {"name": "Elapsed seconds"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connected"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Rain sensing active"},
       "watering": {"name": "Watering"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Pesticide reminder"},
       "reminder_task": {"name": "Task reminder"},
       "reminder_water_shortage": {"name": "Water shortage reminder"}
+    },
+    "image": {
+      "zone_map": {"name": "Zone map"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Zone-map refresh interval (hours)",
           "history_refresh_hours": "History / stats refresh (hours)",
           "reminder_refresh_hours": "Nozzle / reminder refresh (hours)",
-          "weather_refresh_hours": "Weather refresh (hours)"
+          "weather_refresh_hours": "Weather refresh (hours)",
+          "enable_experimental_sensors": "Enable experimental sensors (pesticide usage, skip history)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Total water saved"},
       "total_events": {"name": "Watering events"},
       "last_zone": {"name": "Last watered zone"},
+      "last_skip": {"name": "Last skip reason"},
+      "pesticide_usage": {"name": "Pesticide usage zones"},
       "last_run_water": {"name": "Last run water"},
       "last_run_saving": {"name": "Last run water saved"},
       "last_run_duration": {"name": "Last run duration"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Watering depth"},
+      "rain_threshold": {"name": "Rain threshold"},
+      "wind_threshold": {"name": "Wind threshold"},
       "watering_duration": {"name": "Watering duration"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Rain sensing"},
+      "wind_sensing_switch": {"name": "Wind sensing"},
+      "reminder_drainage": {"name": "Drainage reminder"},
+      "reminder_pesticide": {"name": "Pesticide reminder"},
+      "reminder_task": {"name": "Task reminder"},
+      "reminder_water_shortage": {"name": "Water shortage reminder"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/es.json
+++ b/custom_components/aiper_irrisense/translations/es.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Programaciones"},
       "active_zone": {"name": "Zona activa"},
       "current_dose": {"name": "Dosis actual"},
       "active_elapsed": {"name": "Segundos transcurridos"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT conectado"},
       "online": {"name": "En línea"},
       "rain_sensing": {"name": "Detección de lluvia activa"},
       "watering": {"name": "Riego"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Recordatorio de fitosanitario"},
       "reminder_task": {"name": "Recordatorio de tarea de riego"},
       "reminder_water_shortage": {"name": "Recordatorio de falta de agua"}
+    },
+    "image": {
+      "zone_map": {"name": "Mapa de zonas"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de boquilla"},

--- a/custom_components/aiper_irrisense/translations/es.json
+++ b/custom_components/aiper_irrisense/translations/es.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Zona activa"},
+      "current_dose": {"name": "Dosis actual"},
       "active_elapsed": {"name": "Segundos transcurridos"},
       "active_total": {"name": "Duración total del ciclo (segundos)"},
       "active_progress": {"name": "Progreso"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Ángulo del cabezal"},
       "spray_distance": {"name": "Alcance del chorro"},
       "firmware": {"name": "Versión de firmware"},
-      "water_today": {"name": "Consumo de agua hoy"},
-      "water_week": {"name": "Consumo de agua esta semana"},
-      "water_month": {"name": "Consumo de agua este mes"},
+      "firmware_mcu": {"name": "Firmware MCU"},
+      "firmware_valve": {"name": "Firmware de la válvula"},
+      "wifi_rssi": {"name": "Señal wifi"},
+      "total_water_yield": {"name": "Agua total suministrada"},
+      "total_water_saving": {"name": "Agua total ahorrada"},
+      "total_events": {"name": "Eventos de riego"},
       "last_zone": {"name": "Última zona regada"},
       "last_run_water": {"name": "Agua del último ciclo"},
       "last_run_saving": {"name": "Agua ahorrada en el último ciclo"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "En línea"},
+      "rain_sensing": {"name": "Detección de lluvia activa"},
       "watering": {"name": "Riego"},
       "session_conflict": {"name": "Conflicto de sesión"},
       "last_run_fault": {"name": "Fallo del último ciclo"}
+    },
+    "number": {
+      "watering_depth": {"name": "Profundidad de riego"},
+      "watering_duration": {"name": "Duración de riego"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de boquilla"},

--- a/custom_components/aiper_irrisense/translations/es.json
+++ b/custom_components/aiper_irrisense/translations/es.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Inicia sesión con tu cuenta de Aiper. Solo se añadirán dispositivos IrriSense (prefijo de número de serie WR / WG / WC / WL).",
+        "data": {
+          "username": "Correo electrónico",
+          "password": "Contraseña",
+          "region": "Región"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Volver a autenticar Aiper Irrisense",
+        "description": "Las credenciales guardadas ya no son válidas. Introduce de nuevo tu contraseña.",
+        "data": {
+          "password": "Contraseña"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Credenciales no válidas.",
+      "cannot_connect": "No se pudo conectar con la nube de Aiper.",
+      "no_devices": "No se encontraron dispositivos IrriSense (WR / WG / WC / WL) en esta cuenta.",
+      "unknown": "Error inesperado."
+    },
+    "abort": {
+      "already_configured": "Esta cuenta ya está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de Aiper Irrisense",
+        "data": {
+          "enable_mqtt": "Activar MQTT (actualizaciones en tiempo real)",
+          "mqtt_debug": "Registrar todos los mensajes MQTT (solo depuración)",
+          "poll_interval": "Intervalo de sondeo (segundos)",
+          "map_refresh_hours": "Intervalo de actualización del mapa de zonas (horas)",
+          "history_refresh_hours": "Actualización de historial / estadísticas (horas)",
+          "reminder_refresh_hours": "Actualización de boquilla / recordatorio (horas)",
+          "weather_refresh_hours": "Actualización del tiempo (horas)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Zona activa"},
+      "active_elapsed": {"name": "Segundos transcurridos"},
+      "active_total": {"name": "Duración total del ciclo (segundos)"},
+      "active_progress": {"name": "Progreso"},
+      "active_repair_layer": {"name": "Pasadas de cobertura"},
+      "remaining_time": {"name": "Tiempo restante"},
+      "head_angle": {"name": "Ángulo del cabezal"},
+      "spray_distance": {"name": "Alcance del chorro"},
+      "firmware": {"name": "Versión de firmware"},
+      "water_today": {"name": "Consumo de agua hoy"},
+      "water_week": {"name": "Consumo de agua esta semana"},
+      "water_month": {"name": "Consumo de agua este mes"},
+      "last_zone": {"name": "Última zona regada"},
+      "last_run_water": {"name": "Agua del último ciclo"},
+      "last_run_saving": {"name": "Agua ahorrada en el último ciclo"},
+      "last_run_duration": {"name": "Duración del último ciclo"},
+      "last_run_status": {
+        "name": "Estado del último ciclo",
+        "state": {
+          "completed": "Completado",
+          "fault": "Fallo",
+          "weather_wind": "Omitido – viento",
+          "weather_rain": "Omitido – previsión de lluvia",
+          "on_rain": "Omitido – lluvia",
+          "overlap": "Omitido – solapamiento",
+          "manual_stop": "Detenido manualmente",
+          "water_shortage": "Detenido – sin agua",
+          "manual_task": "Omitido – tarea manual",
+          "conflict": "Omitido – conflicto",
+          "un_completed": "Incompleto"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "En línea"},
+      "watering": {"name": "Riego"},
+      "session_conflict": {"name": "Conflicto de sesión"},
+      "last_run_fault": {"name": "Fallo del último ciclo"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Tipo de boquilla"},
+      "watering_zone": {"name": "Zona de riego"},
+      "watering_dose": {"name": "Dosis"},
+      "watering_duration": {"name": "Duración"}
+    },
+    "button": {
+      "start_watering": {"name": "Iniciar riego"},
+      "stop_watering": {"name": "Detener riego"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Iniciar zona",
+      "description": "Iniciar el riego de una zona específica."
+    },
+    "stop_zone": {
+      "name": "Detener zona",
+      "description": "Detener el riego de una zona específica."
+    },
+    "query_work_info": {
+      "name": "Consultar información de trabajo",
+      "description": "Pedir al dispositivo que publique inmediatamente su instantánea de trabajo actual."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/es.json
+++ b/custom_components/aiper_irrisense/translations/es.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Intervalo de actualización del mapa de zonas (horas)",
           "history_refresh_hours": "Actualización de historial / estadísticas (horas)",
           "reminder_refresh_hours": "Actualización de boquilla / recordatorio (horas)",
-          "weather_refresh_hours": "Actualización del tiempo (horas)"
+          "weather_refresh_hours": "Actualización del tiempo (horas)",
+          "enable_experimental_sensors": "Activar sensores experimentales (uso de fitosanitario, historial de saltos)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Agua total ahorrada"},
       "total_events": {"name": "Eventos de riego"},
       "last_zone": {"name": "Última zona regada"},
+      "last_skip": {"name": "Motivo del último salto"},
+      "pesticide_usage": {"name": "Zonas con fitosanitario"},
       "last_run_water": {"name": "Agua del último ciclo"},
       "last_run_saving": {"name": "Agua ahorrada en el último ciclo"},
       "last_run_duration": {"name": "Duración del último ciclo"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Profundidad de riego"},
+      "rain_threshold": {"name": "Umbral de lluvia"},
+      "wind_threshold": {"name": "Umbral de viento"},
       "watering_duration": {"name": "Duración de riego"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Detección de lluvia"},
+      "wind_sensing_switch": {"name": "Detección de viento"},
+      "reminder_drainage": {"name": "Recordatorio de drenaje"},
+      "reminder_pesticide": {"name": "Recordatorio de fitosanitario"},
+      "reminder_task": {"name": "Recordatorio de tarea de riego"},
+      "reminder_water_shortage": {"name": "Recordatorio de falta de agua"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de boquilla"},

--- a/custom_components/aiper_irrisense/translations/fr.json
+++ b/custom_components/aiper_irrisense/translations/fr.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Programmes"},
       "active_zone": {"name": "Zone active"},
       "current_dose": {"name": "Dose actuelle"},
       "active_elapsed": {"name": "Secondes écoulées"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connecté"},
       "online": {"name": "En ligne"},
       "rain_sensing": {"name": "Détection de pluie active"},
       "watering": {"name": "Arrosage"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Rappel de produit phytosanitaire"},
       "reminder_task": {"name": "Rappel de tâche d'arrosage"},
       "reminder_water_shortage": {"name": "Rappel de manque d'eau"}
+    },
+    "image": {
+      "zone_map": {"name": "Carte des zones"}
     },
     "select": {
       "nozzle_type": {"name": "Type de buse"},

--- a/custom_components/aiper_irrisense/translations/fr.json
+++ b/custom_components/aiper_irrisense/translations/fr.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Zone active"},
+      "current_dose": {"name": "Dose actuelle"},
       "active_elapsed": {"name": "Secondes écoulées"},
       "active_total": {"name": "Durée totale du cycle (secondes)"},
       "active_progress": {"name": "Progression"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Angle de la tête"},
       "spray_distance": {"name": "Portée du jet"},
       "firmware": {"name": "Version du micrologiciel"},
-      "water_today": {"name": "Consommation d'eau aujourd'hui"},
-      "water_week": {"name": "Consommation d'eau cette semaine"},
-      "water_month": {"name": "Consommation d'eau ce mois-ci"},
+      "firmware_mcu": {"name": "Micrologiciel MCU"},
+      "firmware_valve": {"name": "Micrologiciel de la vanne"},
+      "wifi_rssi": {"name": "Signal Wi-Fi"},
+      "total_water_yield": {"name": "Eau totale distribuée"},
+      "total_water_saving": {"name": "Eau totale économisée"},
+      "total_events": {"name": "Cycles d'arrosage"},
       "last_zone": {"name": "Dernière zone arrosée"},
       "last_run_water": {"name": "Eau du dernier cycle"},
       "last_run_saving": {"name": "Eau économisée au dernier cycle"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "En ligne"},
+      "rain_sensing": {"name": "Détection de pluie active"},
       "watering": {"name": "Arrosage"},
       "session_conflict": {"name": "Conflit de session"},
       "last_run_fault": {"name": "Défaut du dernier cycle"}
+    },
+    "number": {
+      "watering_depth": {"name": "Profondeur d'arrosage"},
+      "watering_duration": {"name": "Durée d'arrosage"}
     },
     "select": {
       "nozzle_type": {"name": "Type de buse"},

--- a/custom_components/aiper_irrisense/translations/fr.json
+++ b/custom_components/aiper_irrisense/translations/fr.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Connectez-vous avec votre compte Aiper. Seuls les appareils IrriSense (préfixe de numéro de série WR / WG / WC / WL) seront ajoutés.",
+        "data": {
+          "username": "Adresse e-mail",
+          "password": "Mot de passe",
+          "region": "Région"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Ré-authentifier Aiper Irrisense",
+        "description": "Les identifiants enregistrés ne sont plus valides. Veuillez saisir à nouveau votre mot de passe.",
+        "data": {
+          "password": "Mot de passe"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Identifiants invalides.",
+      "cannot_connect": "Échec de la connexion au cloud Aiper.",
+      "no_devices": "Aucun appareil IrriSense (WR / WG / WC / WL) n'a été trouvé sur ce compte.",
+      "unknown": "Erreur inattendue."
+    },
+    "abort": {
+      "already_configured": "Ce compte est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options Aiper Irrisense",
+        "data": {
+          "enable_mqtt": "Activer MQTT (mises à jour en temps réel)",
+          "mqtt_debug": "Journaliser tous les messages MQTT (débogage uniquement)",
+          "poll_interval": "Intervalle d'interrogation (secondes)",
+          "map_refresh_hours": "Intervalle d'actualisation de la carte des zones (heures)",
+          "history_refresh_hours": "Actualisation de l'historique / des statistiques (heures)",
+          "reminder_refresh_hours": "Actualisation buse / rappel (heures)",
+          "weather_refresh_hours": "Actualisation météo (heures)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Zone active"},
+      "active_elapsed": {"name": "Secondes écoulées"},
+      "active_total": {"name": "Durée totale du cycle (secondes)"},
+      "active_progress": {"name": "Progression"},
+      "active_repair_layer": {"name": "Passages de couverture"},
+      "remaining_time": {"name": "Temps restant"},
+      "head_angle": {"name": "Angle de la tête"},
+      "spray_distance": {"name": "Portée du jet"},
+      "firmware": {"name": "Version du micrologiciel"},
+      "water_today": {"name": "Consommation d'eau aujourd'hui"},
+      "water_week": {"name": "Consommation d'eau cette semaine"},
+      "water_month": {"name": "Consommation d'eau ce mois-ci"},
+      "last_zone": {"name": "Dernière zone arrosée"},
+      "last_run_water": {"name": "Eau du dernier cycle"},
+      "last_run_saving": {"name": "Eau économisée au dernier cycle"},
+      "last_run_duration": {"name": "Durée du dernier cycle"},
+      "last_run_status": {
+        "name": "Statut du dernier cycle",
+        "state": {
+          "completed": "Terminé",
+          "fault": "Défaut",
+          "weather_wind": "Ignoré – vent",
+          "weather_rain": "Ignoré – prévision de pluie",
+          "on_rain": "Ignoré – pluie",
+          "overlap": "Ignoré – chevauchement",
+          "manual_stop": "Arrêté manuellement",
+          "water_shortage": "Arrêté – manque d'eau",
+          "manual_task": "Ignoré – tâche manuelle",
+          "conflict": "Ignoré – conflit",
+          "un_completed": "Incomplet"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "En ligne"},
+      "watering": {"name": "Arrosage"},
+      "session_conflict": {"name": "Conflit de session"},
+      "last_run_fault": {"name": "Défaut du dernier cycle"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Type de buse"},
+      "watering_zone": {"name": "Zone d'arrosage"},
+      "watering_dose": {"name": "Dose"},
+      "watering_duration": {"name": "Durée"}
+    },
+    "button": {
+      "start_watering": {"name": "Démarrer l'arrosage"},
+      "stop_watering": {"name": "Arrêter l'arrosage"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Démarrer la zone",
+      "description": "Démarrer l'arrosage d'une zone spécifique."
+    },
+    "stop_zone": {
+      "name": "Arrêter la zone",
+      "description": "Arrêter l'arrosage d'une zone spécifique."
+    },
+    "query_work_info": {
+      "name": "Interroger les infos de fonctionnement",
+      "description": "Demander à l'appareil de publier immédiatement son instantané de fonctionnement actuel."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/fr.json
+++ b/custom_components/aiper_irrisense/translations/fr.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Intervalle d'actualisation de la carte des zones (heures)",
           "history_refresh_hours": "Actualisation de l'historique / des statistiques (heures)",
           "reminder_refresh_hours": "Actualisation buse / rappel (heures)",
-          "weather_refresh_hours": "Actualisation météo (heures)"
+          "weather_refresh_hours": "Actualisation météo (heures)",
+          "enable_experimental_sensors": "Activer les capteurs expérimentaux (usage phytosanitaire, historique des sauts)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Eau totale économisée"},
       "total_events": {"name": "Cycles d'arrosage"},
       "last_zone": {"name": "Dernière zone arrosée"},
+      "last_skip": {"name": "Motif du dernier saut"},
+      "pesticide_usage": {"name": "Zones avec produit phytosanitaire"},
       "last_run_water": {"name": "Eau du dernier cycle"},
       "last_run_saving": {"name": "Eau économisée au dernier cycle"},
       "last_run_duration": {"name": "Durée du dernier cycle"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Profondeur d'arrosage"},
+      "rain_threshold": {"name": "Seuil de pluie"},
+      "wind_threshold": {"name": "Seuil de vent"},
       "watering_duration": {"name": "Durée d'arrosage"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Détection de pluie"},
+      "wind_sensing_switch": {"name": "Détection du vent"},
+      "reminder_drainage": {"name": "Rappel de vidange"},
+      "reminder_pesticide": {"name": "Rappel de produit phytosanitaire"},
+      "reminder_task": {"name": "Rappel de tâche d'arrosage"},
+      "reminder_water_shortage": {"name": "Rappel de manque d'eau"}
     },
     "select": {
       "nozzle_type": {"name": "Type de buse"},

--- a/custom_components/aiper_irrisense/translations/it.json
+++ b/custom_components/aiper_irrisense/translations/it.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Programmi"},
       "active_zone": {"name": "Zona attiva"},
       "current_dose": {"name": "Dose attuale"},
       "active_elapsed": {"name": "Secondi trascorsi"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT connesso"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Rilevamento pioggia attivo"},
       "watering": {"name": "Irrigazione"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Promemoria fitofarmaco"},
       "reminder_task": {"name": "Promemoria attività di irrigazione"},
       "reminder_water_shortage": {"name": "Promemoria mancanza d'acqua"}
+    },
+    "image": {
+      "zone_map": {"name": "Mappa delle zone"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo di ugello"},

--- a/custom_components/aiper_irrisense/translations/it.json
+++ b/custom_components/aiper_irrisense/translations/it.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Zona attiva"},
+      "current_dose": {"name": "Dose attuale"},
       "active_elapsed": {"name": "Secondi trascorsi"},
       "active_total": {"name": "Durata totale ciclo (secondi)"},
       "active_progress": {"name": "Avanzamento"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Angolo della testina"},
       "spray_distance": {"name": "Gittata"},
       "firmware": {"name": "Versione firmware"},
-      "water_today": {"name": "Consumo d'acqua oggi"},
-      "water_week": {"name": "Consumo d'acqua questa settimana"},
-      "water_month": {"name": "Consumo d'acqua questo mese"},
+      "firmware_mcu": {"name": "Firmware MCU"},
+      "firmware_valve": {"name": "Firmware valvola"},
+      "wifi_rssi": {"name": "Segnale Wi-Fi"},
+      "total_water_yield": {"name": "Acqua totale erogata"},
+      "total_water_saving": {"name": "Acqua totale risparmiata"},
+      "total_events": {"name": "Eventi di irrigazione"},
       "last_zone": {"name": "Ultima zona irrigata"},
       "last_run_water": {"name": "Acqua ultimo ciclo"},
       "last_run_saving": {"name": "Acqua risparmiata ultimo ciclo"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Rilevamento pioggia attivo"},
       "watering": {"name": "Irrigazione"},
       "session_conflict": {"name": "Conflitto di sessione"},
       "last_run_fault": {"name": "Guasto ultimo ciclo"}
+    },
+    "number": {
+      "watering_depth": {"name": "Profondità di irrigazione"},
+      "watering_duration": {"name": "Durata irrigazione"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo di ugello"},

--- a/custom_components/aiper_irrisense/translations/it.json
+++ b/custom_components/aiper_irrisense/translations/it.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Accedi con il tuo account Aiper. Verranno aggiunti solo i dispositivi IrriSense (prefisso del numero di serie WR / WG / WC / WL).",
+        "data": {
+          "username": "Indirizzo e-mail",
+          "password": "Password",
+          "region": "Regione"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Autentica di nuovo Aiper Irrisense",
+        "description": "Le credenziali salvate non sono più valide. Inserisci di nuovo la password.",
+        "data": {
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Credenziali non valide.",
+      "cannot_connect": "Impossibile connettersi al cloud Aiper.",
+      "no_devices": "Nessun dispositivo IrriSense (WR / WG / WC / WL) trovato su questo account.",
+      "unknown": "Errore imprevisto."
+    },
+    "abort": {
+      "already_configured": "Questo account è già configurato."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opzioni Aiper Irrisense",
+        "data": {
+          "enable_mqtt": "Abilita MQTT (aggiornamenti in tempo reale)",
+          "mqtt_debug": "Registra tutti i messaggi MQTT (solo debug)",
+          "poll_interval": "Intervallo di polling (secondi)",
+          "map_refresh_hours": "Intervallo di aggiornamento mappa zone (ore)",
+          "history_refresh_hours": "Aggiornamento cronologia / statistiche (ore)",
+          "reminder_refresh_hours": "Aggiornamento ugello / promemoria (ore)",
+          "weather_refresh_hours": "Aggiornamento meteo (ore)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Zona attiva"},
+      "active_elapsed": {"name": "Secondi trascorsi"},
+      "active_total": {"name": "Durata totale ciclo (secondi)"},
+      "active_progress": {"name": "Avanzamento"},
+      "active_repair_layer": {"name": "Passaggi di copertura"},
+      "remaining_time": {"name": "Tempo rimanente"},
+      "head_angle": {"name": "Angolo della testina"},
+      "spray_distance": {"name": "Gittata"},
+      "firmware": {"name": "Versione firmware"},
+      "water_today": {"name": "Consumo d'acqua oggi"},
+      "water_week": {"name": "Consumo d'acqua questa settimana"},
+      "water_month": {"name": "Consumo d'acqua questo mese"},
+      "last_zone": {"name": "Ultima zona irrigata"},
+      "last_run_water": {"name": "Acqua ultimo ciclo"},
+      "last_run_saving": {"name": "Acqua risparmiata ultimo ciclo"},
+      "last_run_duration": {"name": "Durata ultimo ciclo"},
+      "last_run_status": {
+        "name": "Stato ultimo ciclo",
+        "state": {
+          "completed": "Completato",
+          "fault": "Guasto",
+          "weather_wind": "Saltato – vento",
+          "weather_rain": "Saltato – previsione pioggia",
+          "on_rain": "Saltato – pioggia",
+          "overlap": "Saltato – sovrapposizione",
+          "manual_stop": "Arrestato manualmente",
+          "water_shortage": "Arrestato – acqua assente",
+          "manual_task": "Saltato – attività manuale",
+          "conflict": "Saltato – conflitto",
+          "un_completed": "Incompleto"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "Online"},
+      "watering": {"name": "Irrigazione"},
+      "session_conflict": {"name": "Conflitto di sessione"},
+      "last_run_fault": {"name": "Guasto ultimo ciclo"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Tipo di ugello"},
+      "watering_zone": {"name": "Zona di irrigazione"},
+      "watering_dose": {"name": "Dose"},
+      "watering_duration": {"name": "Durata"}
+    },
+    "button": {
+      "start_watering": {"name": "Avvia irrigazione"},
+      "stop_watering": {"name": "Arresta irrigazione"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Avvia zona",
+      "description": "Avvia l'irrigazione di una zona specifica."
+    },
+    "stop_zone": {
+      "name": "Arresta zona",
+      "description": "Arresta l'irrigazione di una zona specifica."
+    },
+    "query_work_info": {
+      "name": "Interroga informazioni di lavoro",
+      "description": "Chiedi al dispositivo di pubblicare immediatamente l'istantanea di lavoro corrente."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/it.json
+++ b/custom_components/aiper_irrisense/translations/it.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Intervallo di aggiornamento mappa zone (ore)",
           "history_refresh_hours": "Aggiornamento cronologia / statistiche (ore)",
           "reminder_refresh_hours": "Aggiornamento ugello / promemoria (ore)",
-          "weather_refresh_hours": "Aggiornamento meteo (ore)"
+          "weather_refresh_hours": "Aggiornamento meteo (ore)",
+          "enable_experimental_sensors": "Attiva sensori sperimentali (uso fitofarmaco, cronologia salti)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Acqua totale risparmiata"},
       "total_events": {"name": "Eventi di irrigazione"},
       "last_zone": {"name": "Ultima zona irrigata"},
+      "last_skip": {"name": "Motivo dell'ultimo salto"},
+      "pesticide_usage": {"name": "Zone con fitofarmaco"},
       "last_run_water": {"name": "Acqua ultimo ciclo"},
       "last_run_saving": {"name": "Acqua risparmiata ultimo ciclo"},
       "last_run_duration": {"name": "Durata ultimo ciclo"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Profondità di irrigazione"},
+      "rain_threshold": {"name": "Soglia pioggia"},
+      "wind_threshold": {"name": "Soglia vento"},
       "watering_duration": {"name": "Durata irrigazione"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Rilevamento pioggia"},
+      "wind_sensing_switch": {"name": "Rilevamento vento"},
+      "reminder_drainage": {"name": "Promemoria drenaggio"},
+      "reminder_pesticide": {"name": "Promemoria fitofarmaco"},
+      "reminder_task": {"name": "Promemoria attività di irrigazione"},
+      "reminder_water_shortage": {"name": "Promemoria mancanza d'acqua"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo di ugello"},

--- a/custom_components/aiper_irrisense/translations/nl.json
+++ b/custom_components/aiper_irrisense/translations/nl.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Actieve zone"},
+      "current_dose": {"name": "Huidige dosis"},
       "active_elapsed": {"name": "Verstreken seconden"},
       "active_total": {"name": "Totale cyclusduur (seconden)"},
       "active_progress": {"name": "Voortgang"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Kophoek"},
       "spray_distance": {"name": "Sproeiafstand"},
       "firmware": {"name": "Firmwareversie"},
-      "water_today": {"name": "Waterverbruik vandaag"},
-      "water_week": {"name": "Waterverbruik deze week"},
-      "water_month": {"name": "Waterverbruik deze maand"},
+      "firmware_mcu": {"name": "MCU-firmware"},
+      "firmware_valve": {"name": "Klepfirmware"},
+      "wifi_rssi": {"name": "Wifi-signaal"},
+      "total_water_yield": {"name": "Totaal geleverd water"},
+      "total_water_saving": {"name": "Totaal bespaard water"},
+      "total_events": {"name": "Besproeiingsgebeurtenissen"},
       "last_zone": {"name": "Laatst besproeide zone"},
       "last_run_water": {"name": "Water laatste cyclus"},
       "last_run_saving": {"name": "Bespaard water laatste cyclus"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Regendetectie actief"},
       "watering": {"name": "Besproeiing"},
       "session_conflict": {"name": "Sessieconflict"},
       "last_run_fault": {"name": "Storing laatste cyclus"}
+    },
+    "number": {
+      "watering_depth": {"name": "Besproeiingsdiepte"},
+      "watering_duration": {"name": "Besproeiingsduur"}
     },
     "select": {
       "nozzle_type": {"name": "Sproeiertype"},

--- a/custom_components/aiper_irrisense/translations/nl.json
+++ b/custom_components/aiper_irrisense/translations/nl.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Meld je aan met je Aiper-account. Alleen IrriSense-apparaten (serienummer-prefix WR / WG / WC / WL) worden toegevoegd.",
+        "data": {
+          "username": "E-mailadres",
+          "password": "Wachtwoord",
+          "region": "Regio"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Aiper Irrisense opnieuw verifiëren",
+        "description": "De opgeslagen inloggegevens zijn niet meer geldig. Voer je wachtwoord opnieuw in.",
+        "data": {
+          "password": "Wachtwoord"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Ongeldige inloggegevens.",
+      "cannot_connect": "Kan geen verbinding maken met de Aiper-cloud.",
+      "no_devices": "Er zijn geen IrriSense-apparaten (WR / WG / WC / WL) op dit account gevonden.",
+      "unknown": "Onverwachte fout."
+    },
+    "abort": {
+      "already_configured": "Dit account is al geconfigureerd."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Aiper Irrisense-opties",
+        "data": {
+          "enable_mqtt": "MQTT inschakelen (realtime updates)",
+          "mqtt_debug": "Alle MQTT-berichten loggen (alleen foutopsporing)",
+          "poll_interval": "Pollinterval (seconden)",
+          "map_refresh_hours": "Vernieuwingsinterval zonekaart (uren)",
+          "history_refresh_hours": "Vernieuwing geschiedenis / statistieken (uren)",
+          "reminder_refresh_hours": "Vernieuwing sproeier / herinnering (uren)",
+          "weather_refresh_hours": "Weervernieuwing (uren)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Actieve zone"},
+      "active_elapsed": {"name": "Verstreken seconden"},
+      "active_total": {"name": "Totale cyclusduur (seconden)"},
+      "active_progress": {"name": "Voortgang"},
+      "active_repair_layer": {"name": "Dekkingspassages"},
+      "remaining_time": {"name": "Resterende tijd"},
+      "head_angle": {"name": "Kophoek"},
+      "spray_distance": {"name": "Sproeiafstand"},
+      "firmware": {"name": "Firmwareversie"},
+      "water_today": {"name": "Waterverbruik vandaag"},
+      "water_week": {"name": "Waterverbruik deze week"},
+      "water_month": {"name": "Waterverbruik deze maand"},
+      "last_zone": {"name": "Laatst besproeide zone"},
+      "last_run_water": {"name": "Water laatste cyclus"},
+      "last_run_saving": {"name": "Bespaard water laatste cyclus"},
+      "last_run_duration": {"name": "Duur laatste cyclus"},
+      "last_run_status": {
+        "name": "Status laatste cyclus",
+        "state": {
+          "completed": "Voltooid",
+          "fault": "Storing",
+          "weather_wind": "Overgeslagen – wind",
+          "weather_rain": "Overgeslagen – regenverwachting",
+          "on_rain": "Overgeslagen – regen",
+          "overlap": "Overgeslagen – overlap",
+          "manual_stop": "Handmatig gestopt",
+          "water_shortage": "Gestopt – geen water",
+          "manual_task": "Overgeslagen – handmatige taak",
+          "conflict": "Overgeslagen – conflict",
+          "un_completed": "Onvolledig"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "Online"},
+      "watering": {"name": "Besproeiing"},
+      "session_conflict": {"name": "Sessieconflict"},
+      "last_run_fault": {"name": "Storing laatste cyclus"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Sproeiertype"},
+      "watering_zone": {"name": "Besproeiingszone"},
+      "watering_dose": {"name": "Dosis"},
+      "watering_duration": {"name": "Duur"}
+    },
+    "button": {
+      "start_watering": {"name": "Besproeiing starten"},
+      "stop_watering": {"name": "Besproeiing stoppen"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Zone starten",
+      "description": "Start de besproeiing van een specifieke zone."
+    },
+    "stop_zone": {
+      "name": "Zone stoppen",
+      "description": "Stop de besproeiing van een specifieke zone."
+    },
+    "query_work_info": {
+      "name": "Werkinfo opvragen",
+      "description": "Vraag het apparaat om onmiddellijk zijn huidige werkstatus te publiceren."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/nl.json
+++ b/custom_components/aiper_irrisense/translations/nl.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Schema's"},
       "active_zone": {"name": "Actieve zone"},
       "current_dose": {"name": "Huidige dosis"},
       "active_elapsed": {"name": "Verstreken seconden"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT verbonden"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Regendetectie actief"},
       "watering": {"name": "Besproeiing"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Herinnering gewasbescherming"},
       "reminder_task": {"name": "Herinnering besproeiingstaak"},
       "reminder_water_shortage": {"name": "Herinnering watertekort"}
+    },
+    "image": {
+      "zone_map": {"name": "Zonekaart"}
     },
     "select": {
       "nozzle_type": {"name": "Sproeiertype"},

--- a/custom_components/aiper_irrisense/translations/nl.json
+++ b/custom_components/aiper_irrisense/translations/nl.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Vernieuwingsinterval zonekaart (uren)",
           "history_refresh_hours": "Vernieuwing geschiedenis / statistieken (uren)",
           "reminder_refresh_hours": "Vernieuwing sproeier / herinnering (uren)",
-          "weather_refresh_hours": "Weervernieuwing (uren)"
+          "weather_refresh_hours": "Weervernieuwing (uren)",
+          "enable_experimental_sensors": "Experimentele sensoren inschakelen (gewasbeschermingsgebruik, overslaggeschiedenis)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Totaal bespaard water"},
       "total_events": {"name": "Besproeiingsgebeurtenissen"},
       "last_zone": {"name": "Laatst besproeide zone"},
+      "last_skip": {"name": "Reden van laatste overslag"},
+      "pesticide_usage": {"name": "Zones met gewasbescherming"},
       "last_run_water": {"name": "Water laatste cyclus"},
       "last_run_saving": {"name": "Bespaard water laatste cyclus"},
       "last_run_duration": {"name": "Duur laatste cyclus"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Besproeiingsdiepte"},
+      "rain_threshold": {"name": "Regendrempel"},
+      "wind_threshold": {"name": "Winddrempel"},
       "watering_duration": {"name": "Besproeiingsduur"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Regendetectie"},
+      "wind_sensing_switch": {"name": "Winddetectie"},
+      "reminder_drainage": {"name": "Herinnering aftappen"},
+      "reminder_pesticide": {"name": "Herinnering gewasbescherming"},
+      "reminder_task": {"name": "Herinnering besproeiingstaak"},
+      "reminder_water_shortage": {"name": "Herinnering watertekort"}
     },
     "select": {
       "nozzle_type": {"name": "Sproeiertype"},

--- a/custom_components/aiper_irrisense/translations/pt.json
+++ b/custom_components/aiper_irrisense/translations/pt.json
@@ -1,0 +1,113 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Aiper Irrisense 2",
+        "description": "Inicie sessão com a sua conta Aiper. Apenas serão adicionados dispositivos IrriSense (prefixo de número de série WR / WG / WC / WL).",
+        "data": {
+          "username": "Endereço de e-mail",
+          "password": "Palavra-passe",
+          "region": "Região"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reautenticar Aiper Irrisense",
+        "description": "As credenciais guardadas já não são válidas. Introduza novamente a sua palavra-passe.",
+        "data": {
+          "password": "Palavra-passe"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Credenciais inválidas.",
+      "cannot_connect": "Falha ao ligar à cloud Aiper.",
+      "no_devices": "Não foram encontrados dispositivos IrriSense (WR / WG / WC / WL) nesta conta.",
+      "unknown": "Erro inesperado."
+    },
+    "abort": {
+      "already_configured": "Esta conta já está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opções Aiper Irrisense",
+        "data": {
+          "enable_mqtt": "Ativar MQTT (atualizações em tempo real)",
+          "mqtt_debug": "Registar todas as mensagens MQTT (apenas depuração)",
+          "poll_interval": "Intervalo de consulta (segundos)",
+          "map_refresh_hours": "Intervalo de atualização do mapa de zonas (horas)",
+          "history_refresh_hours": "Atualização de histórico / estatísticas (horas)",
+          "reminder_refresh_hours": "Atualização de bico / lembrete (horas)",
+          "weather_refresh_hours": "Atualização meteorológica (horas)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_zone": {"name": "Zona ativa"},
+      "active_elapsed": {"name": "Segundos decorridos"},
+      "active_total": {"name": "Duração total do ciclo (segundos)"},
+      "active_progress": {"name": "Progresso"},
+      "active_repair_layer": {"name": "Passagens de cobertura"},
+      "remaining_time": {"name": "Tempo restante"},
+      "head_angle": {"name": "Ângulo da cabeça"},
+      "spray_distance": {"name": "Alcance do jato"},
+      "firmware": {"name": "Versão de firmware"},
+      "water_today": {"name": "Consumo de água hoje"},
+      "water_week": {"name": "Consumo de água esta semana"},
+      "water_month": {"name": "Consumo de água este mês"},
+      "last_zone": {"name": "Última zona regada"},
+      "last_run_water": {"name": "Água do último ciclo"},
+      "last_run_saving": {"name": "Água poupada no último ciclo"},
+      "last_run_duration": {"name": "Duração do último ciclo"},
+      "last_run_status": {
+        "name": "Estado do último ciclo",
+        "state": {
+          "completed": "Concluído",
+          "fault": "Falha",
+          "weather_wind": "Ignorado – vento",
+          "weather_rain": "Ignorado – previsão de chuva",
+          "on_rain": "Ignorado – chuva",
+          "overlap": "Ignorado – sobreposição",
+          "manual_stop": "Parado manualmente",
+          "water_shortage": "Parado – sem água",
+          "manual_task": "Ignorado – tarefa manual",
+          "conflict": "Ignorado – conflito",
+          "un_completed": "Incompleto"
+        }
+      }
+    },
+    "binary_sensor": {
+      "online": {"name": "Online"},
+      "watering": {"name": "Rega"},
+      "session_conflict": {"name": "Conflito de sessão"},
+      "last_run_fault": {"name": "Falha do último ciclo"}
+    },
+    "select": {
+      "nozzle_type": {"name": "Tipo de bico"},
+      "watering_zone": {"name": "Zona de rega"},
+      "watering_dose": {"name": "Dose"},
+      "watering_duration": {"name": "Duração"}
+    },
+    "button": {
+      "start_watering": {"name": "Iniciar rega"},
+      "stop_watering": {"name": "Parar rega"}
+    }
+  },
+  "services": {
+    "start_zone": {
+      "name": "Iniciar zona",
+      "description": "Iniciar a rega de uma zona específica."
+    },
+    "stop_zone": {
+      "name": "Parar zona",
+      "description": "Parar a rega de uma zona específica."
+    },
+    "query_work_info": {
+      "name": "Consultar informação de trabalho",
+      "description": "Pedir ao dispositivo para publicar imediatamente o seu instantâneo de trabalho atual."
+    }
+  }
+}

--- a/custom_components/aiper_irrisense/translations/pt.json
+++ b/custom_components/aiper_irrisense/translations/pt.json
@@ -47,6 +47,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Zona ativa"},
+      "current_dose": {"name": "Dose atual"},
       "active_elapsed": {"name": "Segundos decorridos"},
       "active_total": {"name": "Duração total do ciclo (segundos)"},
       "active_progress": {"name": "Progresso"},
@@ -55,9 +56,12 @@
       "head_angle": {"name": "Ângulo da cabeça"},
       "spray_distance": {"name": "Alcance do jato"},
       "firmware": {"name": "Versão de firmware"},
-      "water_today": {"name": "Consumo de água hoje"},
-      "water_week": {"name": "Consumo de água esta semana"},
-      "water_month": {"name": "Consumo de água este mês"},
+      "firmware_mcu": {"name": "Firmware MCU"},
+      "firmware_valve": {"name": "Firmware da válvula"},
+      "wifi_rssi": {"name": "Sinal Wi-Fi"},
+      "total_water_yield": {"name": "Água total fornecida"},
+      "total_water_saving": {"name": "Água total poupada"},
+      "total_events": {"name": "Eventos de rega"},
       "last_zone": {"name": "Última zona regada"},
       "last_run_water": {"name": "Água do último ciclo"},
       "last_run_saving": {"name": "Água poupada no último ciclo"},
@@ -81,9 +85,14 @@
     },
     "binary_sensor": {
       "online": {"name": "Online"},
+      "rain_sensing": {"name": "Deteção de chuva ativa"},
       "watering": {"name": "Rega"},
       "session_conflict": {"name": "Conflito de sessão"},
       "last_run_fault": {"name": "Falha do último ciclo"}
+    },
+    "number": {
+      "watering_depth": {"name": "Profundidade de rega"},
+      "watering_duration": {"name": "Duração da rega"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de bico"},

--- a/custom_components/aiper_irrisense/translations/pt.json
+++ b/custom_components/aiper_irrisense/translations/pt.json
@@ -47,6 +47,7 @@
   },
   "entity": {
     "sensor": {
+      "schedules": {"name": "Programações"},
       "active_zone": {"name": "Zona ativa"},
       "current_dose": {"name": "Dose atual"},
       "active_elapsed": {"name": "Segundos decorridos"},
@@ -87,6 +88,7 @@
       }
     },
     "binary_sensor": {
+      "mqtt_connected": {"name": "MQTT ligado"},
       "online": {"name": "Online"},
       "rain_sensing": {"name": "Deteção de chuva ativa"},
       "watering": {"name": "Rega"},
@@ -106,6 +108,9 @@
       "reminder_pesticide": {"name": "Lembrete de fitofármaco"},
       "reminder_task": {"name": "Lembrete de tarefa de rega"},
       "reminder_water_shortage": {"name": "Lembrete de falta de água"}
+    },
+    "image": {
+      "zone_map": {"name": "Mapa de zonas"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de bico"},

--- a/custom_components/aiper_irrisense/translations/pt.json
+++ b/custom_components/aiper_irrisense/translations/pt.json
@@ -39,7 +39,8 @@
           "map_refresh_hours": "Intervalo de atualização do mapa de zonas (horas)",
           "history_refresh_hours": "Atualização de histórico / estatísticas (horas)",
           "reminder_refresh_hours": "Atualização de bico / lembrete (horas)",
-          "weather_refresh_hours": "Atualização meteorológica (horas)"
+          "weather_refresh_hours": "Atualização meteorológica (horas)",
+          "enable_experimental_sensors": "Ativar sensores experimentais (uso de fitofármaco, histórico de saltos)"
         }
       }
     }
@@ -63,6 +64,8 @@
       "total_water_saving": {"name": "Água total poupada"},
       "total_events": {"name": "Eventos de rega"},
       "last_zone": {"name": "Última zona regada"},
+      "last_skip": {"name": "Motivo do último salto"},
+      "pesticide_usage": {"name": "Zonas com fitofármaco"},
       "last_run_water": {"name": "Água do último ciclo"},
       "last_run_saving": {"name": "Água poupada no último ciclo"},
       "last_run_duration": {"name": "Duração do último ciclo"},
@@ -92,7 +95,17 @@
     },
     "number": {
       "watering_depth": {"name": "Profundidade de rega"},
+      "rain_threshold": {"name": "Limiar de chuva"},
+      "wind_threshold": {"name": "Limiar de vento"},
       "watering_duration": {"name": "Duração da rega"}
+    },
+    "switch": {
+      "rain_sensing_switch": {"name": "Deteção de chuva"},
+      "wind_sensing_switch": {"name": "Deteção de vento"},
+      "reminder_drainage": {"name": "Lembrete de drenagem"},
+      "reminder_pesticide": {"name": "Lembrete de fitofármaco"},
+      "reminder_task": {"name": "Lembrete de tarefa de rega"},
+      "reminder_water_shortage": {"name": "Lembrete de falta de água"}
     },
     "select": {
       "nozzle_type": {"name": "Tipo de bico"},


### PR DESCRIPTION
Adds German, French, Spanish, Italian, Portuguese and Dutch locale files, and makes them actually take effect.

**Two parts**

1. The six locale files (mirroring `en.json`, using irrigation-context terms, e.g. throw distance becomes `Wurfweite` / `Gittata` / `Sproeiafstand`).
2. The fix that makes them visible: every entity set both `_attr_name` and `_attr_translation_key`, and `_attr_name` wins, so names always rendered in English regardless of the translations. This drops the per-entity `_attr_name` (keeping `has_entity_name` + `translation_key`) on the sensor / binary_sensor / select / button entities, and reconciles the translation keys with the code (adds firmware_mcu/valve, wifi_rssi, total_water_yield/saving, total_events, rain_sensing; drops the orphan water_today/week/month keys).

Verified on a live instance: with `_attr_name` gone, a German frontend renders the translated names.

`en.json` and the locales are kept in parity. The files also carry keys for entities from the open sensor PRs (spray-distance, schedules, and so on), which are inert until those PRs land. `pt` is European; language codes follow HA's ISO-639-1 convention.