### PR TITLE
Add free dose / duration Number entities + current-dose sensor

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -29,6 +29,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
     Platform.SELECT,
+    Platform.NUMBER,
     Platform.BUTTON,
 ]
 # Dose lives on the Watering Dose select (label-valued: "3 mm" / "5 min" / ...)

--- a/custom_components/aiper_irrisense/const.py
+++ b/custom_components/aiper_irrisense/const.py
@@ -1,6 +1,8 @@
 """Constants for the Aiper Irrisense 2 integration."""
 from __future__ import annotations
 
+import re
+
 from typing import Final
 
 DOMAIN: Final = "aiper_irrisense"
@@ -92,6 +94,16 @@ POINT_TIME_MEDIUM: Final = 5
 POINT_TIME_HIGH: Final = 10
 POINT_TIME_PRESETS: Final = (POINT_TIME_LOW, POINT_TIME_MEDIUM, POINT_TIME_HIGH)
 
+# Free dose bounds — the device accepts the full slider range, not just the
+# three presets (2026-07). Depth: 0.1..0.9 in on the wire, shown mm x25.4
+# (3..23 mm; 1.0 in / 25 mm is NOT selectable). Point time: 1..150 minutes.
+WATER_YIELD_MIN: Final = 0.1
+WATER_YIELD_MAX: Final = 0.9
+DEPTH_MM_MIN: Final = 3
+DEPTH_MM_MAX: Final = 23
+POINT_TIME_MIN: Final = 1
+POINT_TIME_MAX: Final = 150
+
 # ---- Dose / Duration labels (shown in the HA Select) ----------------------
 # The Aiper app displays the three waterYield presets as "3 mm / 6 mm / 13 mm"
 # and the three point_time presets as "1 min / 5 min / 10 min". We keep the
@@ -144,6 +156,7 @@ def parse_dose_label(label: str) -> tuple[str, float | int] | None:
     Returns a tuple ``(kind, value)`` where ``kind`` is ``"waterYield"`` for
     Area/Line presets and ``"point_time"`` for Point presets. Returns None
     on unknown labels so callers can fall back to the zone-map default.
+    Preset labels win; free "N mm" / "N min" values are parsed too.
     """
     for wy, lbl in WATER_YIELD_LABELS.items():
         if lbl == label:
@@ -151,6 +164,16 @@ def parse_dose_label(label: str) -> tuple[str, float | int] | None:
     for pt, lbl in POINT_TIME_LABELS.items():
         if lbl == label:
             return ("point_time", pt)
+    # Free (non-preset) values from the Number entities: "18 mm" / "120 min".
+    # Depth is shown in mm but sent as the inch float (1 in = 25.4 mm); the
+    # device accepts the full 0.1..0.9 in / 1..150 min range, not just the
+    # three presets above.
+    m = re.fullmatch(r"(\d+(?:\.\d+)?) mm", label)
+    if m:
+        return ("waterYield", float(m.group(1)) / 25.4)
+    m = re.fullmatch(r"(\d+) min", label)
+    if m:
+        return ("point_time", int(m.group(1)))
     return None
 
 

--- a/custom_components/aiper_irrisense/coordinator.py
+++ b/custom_components/aiper_irrisense/coordinator.py
@@ -44,7 +44,11 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     POINT_TIME_LOW,
+    POINT_TIME_MAX,
+    POINT_TIME_MIN,
     POINT_TIME_PRESETS,
+    WATER_YIELD_MAX,
+    WATER_YIELD_MIN,
     REGION_TYPE_POINT,
     WATER_YIELD_LOW,
     WATER_YIELD_PRESETS,
@@ -476,15 +480,14 @@ class IrrisenseCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         if resolved_type == REGION_TYPE_POINT:
             if point_time is None:
                 point_time = int(region.get("pointTime", POINT_TIME_LOW)) if region else POINT_TIME_LOW
-            kwargs["point_time"] = _snap_to_preset(
-                int(point_time), POINT_TIME_PRESETS, "point_time (minutes)",
-            )
+            # Free value: the device accepts the full 1..150 min range, not
+            # just the presets. Clamp to the device bounds instead of snapping.
+            kwargs["point_time"] = max(POINT_TIME_MIN, min(POINT_TIME_MAX, int(point_time)))
         else:
             if water_yield is None:
                 water_yield = float(region.get("waterYield", WATER_YIELD_LOW)) if region else WATER_YIELD_LOW
-            kwargs["water_yield"] = _snap_to_preset(
-                float(water_yield), WATER_YIELD_PRESETS, "waterYield",
-            )
+            # Free value: the device accepts 0.1..0.9 in; clamp, do not snap.
+            kwargs["water_yield"] = max(WATER_YIELD_MIN, min(WATER_YIELD_MAX, float(water_yield)))
 
         _LOGGER.debug(
             "async_start_zone resolved sn=%s map_id=%s region=%s → kwargs=%s",

--- a/custom_components/aiper_irrisense/number.py
+++ b/custom_components/aiper_irrisense/number.py
@@ -90,7 +90,6 @@ class DepthNumber(_DoseNumberBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "watering_depth")
-        self._attr_name = "Watering depth"
 
     def _label_for(self, value: float) -> str:
         return f"{int(round(value))} mm"
@@ -107,7 +106,6 @@ class DurationNumber(_DoseNumberBase):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "watering_duration")
-        self._attr_name = "Watering duration"
 
     def _label_for(self, value: float) -> str:
         return f"{int(round(value))} min"

--- a/custom_components/aiper_irrisense/number.py
+++ b/custom_components/aiper_irrisense/number.py
@@ -1,0 +1,113 @@
+"""Number platform: free dose / duration input.
+
+Complements the Dose select. The Aiper app exposes the full slider range —
+depth 0.1..0.9 inch (shown as 3..23 mm) and point time 1..150 minutes — far
+wider than the three presets the Dose select offers. These Number entities
+let the user set any in-range value. The value is written to the same dose
+selection the Dose select and Start button read, so the most recent of the
+two wins.
+"""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfLength, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import (
+    DEPTH_MM_MAX,
+    DEPTH_MM_MIN,
+    DOMAIN,
+    POINT_TIME_MAX,
+    POINT_TIME_MIN,
+)
+from .coordinator import IrrisenseCoordinator
+from .entity import IrrisenseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: IrrisenseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[NumberEntity] = []
+    for dev in coordinator.devices:
+        sn = dev.get("sn")
+        if not sn:
+            continue
+        entities.append(DepthNumber(coordinator, sn))
+        entities.append(DurationNumber(coordinator, sn))
+    async_add_entities(entities)
+
+
+class _DoseNumberBase(IrrisenseEntity, RestoreEntity, NumberEntity):
+    """Free dose/duration input that feeds the shared dose selection.
+
+    Holds its own last-entered value (restored across restarts). Writing it
+    also updates the coordinator's dose selection as a label the Start button
+    parses, so the Number and the Dose select share one 'what will Start use'
+    value on a last-writer-wins basis.
+    """
+
+    _attr_mode = NumberMode.BOX
+    _attr_native_step = 1
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str, key: str) -> None:
+        super().__init__(coordinator, sn, key)
+        self._value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        if last and last.state not in (None, "unknown", "unavailable"):
+            try:
+                self._value = float(last.state)
+            except (TypeError, ValueError):
+                self._value = None
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._value = value
+        self.coordinator.set_dose_selection(self._sn, self._label_for(value))
+        self.async_write_ha_state()
+
+    def _label_for(self, value: float) -> str:
+        raise NotImplementedError
+
+
+class DepthNumber(_DoseNumberBase):
+    """Watering depth in mm (Area/Line zones), 3..23 mm."""
+
+    _attr_translation_key = "watering_depth"
+    _attr_icon = "mdi:water"
+    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
+    _attr_native_min_value = float(DEPTH_MM_MIN)
+    _attr_native_max_value = float(DEPTH_MM_MAX)
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "watering_depth")
+        self._attr_name = "Watering depth"
+
+    def _label_for(self, value: float) -> str:
+        return f"{int(round(value))} mm"
+
+
+class DurationNumber(_DoseNumberBase):
+    """Watering duration in minutes (Point zones), 1..150 min."""
+
+    _attr_translation_key = "watering_duration"
+    _attr_icon = "mdi:timer-outline"
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_native_min_value = float(POINT_TIME_MIN)
+    _attr_native_max_value = float(POINT_TIME_MAX)
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "watering_duration")
+        self._attr_name = "Watering duration"
+
+    def _label_for(self, value: float) -> str:
+        return f"{int(round(value))} min"

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
         entities.extend(
             [
                 ActiveZoneSensor(coordinator, sn),
+                CurrentDoseSensor(coordinator, sn),
                 ActiveElapsedSensor(coordinator, sn),
                 ActiveTotalSensor(coordinator, sn),
                 ActiveProgressSensor(coordinator, sn),
@@ -136,6 +137,25 @@ class ActiveZoneSensor(IrrisenseEntity, SensorEntity):
             # rather than tick down a fake 5 minutes.
             "duration_pending": state.get("duration_pending", False),
         }
+
+
+class CurrentDoseSensor(IrrisenseEntity, SensorEntity):
+    """The dose / duration the next Start will use.
+
+    Mirrors the shared dose selection last written by the Dose select or the
+    depth / duration Number entities, as a label like "13 mm" or "120 min".
+    """
+
+    _attr_icon = "mdi:water-percent"
+    _attr_translation_key = "current_dose"
+
+    def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
+        super().__init__(coordinator, sn, "current_dose")
+        self._attr_name = "Current dose"
+
+    @property
+    def native_value(self) -> str | None:
+        return self.coordinator.get_dose_selection(self._sn)
 
 
 # --------------------------------------------------------------------------- #

--- a/custom_components/aiper_irrisense/sensor.py
+++ b/custom_components/aiper_irrisense/sensor.py
@@ -151,7 +151,6 @@ class CurrentDoseSensor(IrrisenseEntity, SensorEntity):
 
     def __init__(self, coordinator: IrrisenseCoordinator, sn: str) -> None:
         super().__init__(coordinator, sn, "current_dose")
-        self._attr_name = "Current dose"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/aiper_irrisense/strings.json
+++ b/custom_components/aiper_irrisense/strings.json
@@ -45,6 +45,7 @@
   },
   "entity": {
     "sensor": {
+      "current_dose": {"name": "Current dose"},
       "active_zone": {"name": "Active zone"},
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
@@ -59,6 +60,10 @@
     "binary_sensor": {
       "online": {"name": "Online"},
       "watering": {"name": "Watering"}
+    },
+    "number": {
+      "watering_depth": {"name": "Watering depth"},
+      "watering_duration": {"name": "Watering duration"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/custom_components/aiper_irrisense/translations/en.json
+++ b/custom_components/aiper_irrisense/translations/en.json
@@ -46,6 +46,7 @@
   "entity": {
     "sensor": {
       "active_zone": {"name": "Active zone"},
+      "current_dose": {"name": "Current dose"},
       "active_elapsed": {"name": "Elapsed seconds"},
       "active_total": {"name": "Run total seconds"},
       "active_progress": {"name": "Progress"},
@@ -59,6 +60,10 @@
     "binary_sensor": {
       "online": {"name": "Online"},
       "watering": {"name": "Watering"}
+    },
+    "number": {
+      "watering_depth": {"name": "Watering depth"},
+      "watering_duration": {"name": "Watering duration"}
     },
     "select": {
       "nozzle_type": {"name": "Nozzle type"},

--- a/tests/test_dose.py
+++ b/tests/test_dose.py
@@ -1,0 +1,49 @@
+"""Unit tests for dose-label parsing, including free (non-preset) values.
+
+`const.py` is stdlib-only, so we file-load it directly.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+_CONST_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "custom_components" / "aiper_irrisense" / "const.py"
+)
+_spec = importlib.util.spec_from_file_location("const", _CONST_PATH)
+const = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(const)
+
+MM = 25.4
+
+
+def test_presets_unchanged():
+    assert const.parse_dose_label("3 mm") == ("waterYield", 0.1)
+    assert const.parse_dose_label("6 mm") == ("waterYield", 0.25)
+    assert const.parse_dose_label("13 mm") == ("waterYield", 0.5)
+    assert const.parse_dose_label("1 min") == ("point_time", 1)
+    assert const.parse_dose_label("5 min") == ("point_time", 5)
+    assert const.parse_dose_label("10 min") == ("point_time", 10)
+
+
+def test_free_mm_maps_to_inch():
+    kind, val = const.parse_dose_label("18 mm")
+    assert kind == "waterYield"
+    assert val == pytest.approx(18 / MM)
+    kind, val = const.parse_dose_label("23 mm")
+    assert kind == "waterYield"
+    assert val == pytest.approx(23 / MM)
+
+
+def test_free_minutes():
+    assert const.parse_dose_label("120 min") == ("point_time", 120)
+    assert const.parse_dose_label("150 min") == ("point_time", 150)
+
+
+def test_garbage_is_none():
+    assert const.parse_dose_label("abc") is None
+    assert const.parse_dose_label("") is None
+    assert const.parse_dose_label("mm") is None
+    assert const.parse_dose_label("5 mmm") is None
+    assert const.parse_dose_label("min") is None


### PR DESCRIPTION
Adds free-value dose input, complementing the three-preset Dose select.

The Aiper app's slider accepts far more than the three presets the integration exposes: depth up to ~23 mm and point time up to 150 minutes. This adds two Number entities so any in-range value can be used:

- `number.watering_depth` (3..23 mm, for Area/Line zones)
- `number.watering_duration` (1..150 min, for Point zones)

Both write the same dose selection the Dose select and the Start button already read, so the most recent of the two wins and the Start button is unchanged. `sensor.current_dose` surfaces the effective selection (e.g. "13 mm" / "120 min").

`parse_dose_label` now also parses free "N mm" / "N min" values (the presets still take precedence), and `async_start_zone` clamps to the device's accepted range instead of snapping to the nearest preset. `_snap_to_preset` stays in the file but is now unused.

**Depth ceiling** – the app's depth control tops out at 0.9 inch (~23 mm), so the Number caps there rather than at 25 mm.

**Testing** – pure unit tests for the free-value `parse_dose_label` parsing. Verified on a device that setting `number.watering_depth` is reflected in `sensor.current_dose`.

Only `en.json` is touched here; the other locales follow the translations PR.
