### PR TITLE
fix: unload the platforms that were actually forwarded

### DIFF
--- a/custom_components/aiper_irrisense/__init__.py
+++ b/custom_components/aiper_irrisense/__init__.py
@@ -46,8 +46,12 @@ def _platforms_for(entry: ConfigEntry) -> list[Platform]:
     """Platforms to set up for this entry.
 
     Weather is opt-in (it sends HA home coordinates to Aiper's cloud), so the
-    WEATHER platform is only forwarded when the option is enabled. The entry
-    reloads on options change, so setup and unload always see the same set.
+    WEATHER platform is only forwarded when the option is enabled.
+
+    Only call this at setup time. Unloading has to use the platform list that
+    was actually forwarded (kept in the `hass.data` slot): on the reload that
+    follows an options change the new options are already stored, so this would
+    return a different set than the one that was set up.
     """
     platforms = list(PLATFORMS)
     if entry.options.get(CONF_ENABLE_WEATHER, DEFAULT_ENABLE_WEATHER):
@@ -205,12 +209,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             serial_number=sn,
         )
 
+    platforms = _platforms_for(entry)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "api": api,
         "coordinator": coordinator,
+        "platforms": platforms,
     }
 
-    await hass.config_entries.async_forward_entry_setups(entry, _platforms_for(entry))
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
     # Reload on options change
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -261,8 +267,15 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Tear down an account."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, _platforms_for(entry))
-    slot = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    slot = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    # Unload exactly what was forwarded at setup. On the reload that follows an
+    # options change the new options are already stored, so recomputing the list
+    # here would try to unload a platform that was never set up (see #55).
+    platforms = slot["platforms"] if slot else _platforms_for(entry)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
+    if not unload_ok:
+        return False
+    hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
     if slot:
         api: IrrisenseApi = slot["api"]
         await hass.async_add_executor_job(api.disconnect)


### PR DESCRIPTION
Closes #55.

Turning the **Enable weather** option on for a loaded entry left it stuck in `failed_unload` and took every entity of the integration down until a full Home Assistant restart.

### Why it happened

`async_setup_entry` and `async_unload_entry` both derived their platform list from `_platforms_for(entry)`, which reads the *current* options. The options-update listener runs after the new options have been stored, so the unload half of the reload already saw `enable_weather: true` while setup had forwarded the list without `Platform.WEATHER`. Unloading a platform that was never set up raises `ValueError("Config entry was never loaded!")` inside `entity_component`, so `async_unload_platforms` returned `False` and the entry was marked `failed_unload`.

The same mismatch has a quieter counterpart in the other direction, which I only noticed while verifying this branch: turning the option **off** makes the unload compute a list *without* `Platform.WEATHER`, so the weather platform is never unloaded at all. It stays loaded with its entities live and updating, and the opt-out does not take effect until the next restart. Both directions come from the same disagreement and are fixed by the same change.

`Platform.WEATHER` is the only conditional platform in the integration, so weather is the only option that can trigger either effect. The experimental-sensors option adds entities inside an already-forwarded platform and is unaffected.

### What changed

- The list that was actually forwarded is kept in the `hass.data` slot and reused on unload, so setup and unload can never disagree.
- `_platforms_for` grew a note that it is setup-only, replacing the docstring line that claimed setup and unload always see the same set.
- `async_unload_entry` returns early when the unload fails. Previously the teardown below ran regardless: the slot was popped and `api.disconnect()` was called even for an entry Home Assistant still considered loaded.

### Testing

The existing tests all cover pure helper modules that avoid importing Home Assistant, and there is no test harness for `__init__.py`, so I did not add one for this.

Verified on a live instance: Home Assistant Core 2026.7.4, integration 0.4.1, two devices. I applied this branch's diff to the installed copy and checked the result against the diff hunk for hunk before testing.

Before the fix, with the entry set up while weather was off, switching it on reproduced the reported failure exactly: entry state `failed_unload`, and the `ValueError: Config entry was never loaded!` traceback from #55, logged at the moment of the options write.

After the fix, on the same instance:

- Switching weather **off** now unloads the platform — both weather entities go `unavailable`. Before the fix they stayed on their last state and kept updating.
- Switching weather **on** leaves the entry `loaded`, logs no error, and the weather entities come back without a restart.

One caveat for anyone reproducing this: do not switch the option off first as a way to reach the "weather off" starting state. That off-toggle leaks the weather platform, so the following on-toggle finds it loaded and unloads it cleanly, and the crash does not appear. The starting state has to come from a setup that ran with weather off, as the steps in #55 describe.
